### PR TITLE
fix: Remove unused React import in ErrorBoundary

### DIFF
--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { Component, ErrorInfo, ReactNode } from 'react';
 
 interface Props {
   children: ReactNode;


### PR DESCRIPTION
Remove unused React import to fix TypeScript compilation error.
The Component, ErrorInfo, and ReactNode imports are sufficient.