### PR TITLE
fix: Make left panel scrollable when simulation selector is visible

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -186,39 +186,41 @@ function App() {
             disabled={activeSim.isRunning}
           />
 
-          {simulationType === 'rocket' ? (
-            <ControlPanel
-              isReady={rocketSim.isReady}
-              isInitialized={rocketSim.isInitialized}
-              isRunning={rocketSim.isRunning}
-              error={rocketSim.error}
-              playbackSpeed={rocketSim.playbackSpeed}
-              onInitialize={rocketSim.initialize}
-              onStart={rocketSim.start}
-              onPause={rocketSim.pause}
-              onReset={rocketSim.reset}
-              onStep={rocketSim.step}
-              onPlaybackSpeedChange={rocketSim.setPlaybackSpeed}
-            />
-          ) : (
-            <Grid2DControlPanel
-              isReady={gridSim.isReady}
-              isInitialized={gridSim.isInitialized}
-              isRunning={gridSim.isRunning}
-              error={gridSim.error}
-              playbackSpeed={gridSim.playbackSpeed}
-              onInitialize={gridSim.initialize}
-              onStart={gridSim.start}
-              onPause={gridSim.pause}
-              onReset={gridSim.reset}
-              onStep={gridSim.step}
-              onPlaybackSpeedChange={gridSim.setPlaybackSpeed}
-              showVelocities={showVelocities}
-              showGrid={showGrid}
-              onShowVelocitiesChange={setShowVelocities}
-              onShowGridChange={setShowGrid}
-            />
-          )}
+          <div style={styles.controlPanelWrapper}>
+            {simulationType === 'rocket' ? (
+              <ControlPanel
+                isReady={rocketSim.isReady}
+                isInitialized={rocketSim.isInitialized}
+                isRunning={rocketSim.isRunning}
+                error={rocketSim.error}
+                playbackSpeed={rocketSim.playbackSpeed}
+                onInitialize={rocketSim.initialize}
+                onStart={rocketSim.start}
+                onPause={rocketSim.pause}
+                onReset={rocketSim.reset}
+                onStep={rocketSim.step}
+                onPlaybackSpeedChange={rocketSim.setPlaybackSpeed}
+              />
+            ) : (
+              <Grid2DControlPanel
+                isReady={gridSim.isReady}
+                isInitialized={gridSim.isInitialized}
+                isRunning={gridSim.isRunning}
+                error={gridSim.error}
+                playbackSpeed={gridSim.playbackSpeed}
+                onInitialize={gridSim.initialize}
+                onStart={gridSim.start}
+                onPause={gridSim.pause}
+                onReset={gridSim.reset}
+                onStep={gridSim.step}
+                onPlaybackSpeedChange={gridSim.setPlaybackSpeed}
+                showVelocities={showVelocities}
+                showGrid={showGrid}
+                onShowVelocitiesChange={setShowVelocities}
+                onShowGridChange={setShowGrid}
+              />
+            )}
+          </div>
         </div>
 
         {/* Center Panel: Visualization */}
@@ -287,7 +289,14 @@ const styles = {
     width: '320px',
     height: '100%',
     borderRight: '2px solid #34495e',
+    display: 'flex',
+    flexDirection: 'column' as const,
     overflow: 'hidden',
+  },
+  controlPanelWrapper: {
+    flex: 1,
+    minHeight: 0,
+    overflow: 'auto',
   },
   centerPanel: {
     flex: 1,


### PR DESCRIPTION
## Summary
- Fixed UX issue where the simulation type selector was hiding the Initialize/Start buttons
- Made the left panel a flex container so the control panel can scroll independently
- Users can now see and access all controls regardless of viewport size

## Problem
When the simulation type selector was added at the top of the left panel, the control panel content (including Initialize and Start buttons) was pushed out of view due to `overflow: hidden` on the parent container.

## Solution
- Changed leftPanel to use flexbox with column direction
- Added a controlPanelWrapper that takes remaining space with `flex: 1`
- The wrapper has `overflow: auto` so users can scroll to see all controls

Fixes #17

@claude please review this PR

## Test plan
- [ ] Open the web app
- [ ] Verify simulation type selector is visible at the top
- [ ] Verify Initialize button is visible and accessible
- [ ] Switch between rocket and grid simulations
- [ ] Verify all control buttons remain accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)