### PR TITLE
fix: Make rocket point upward by default in 3D visualization

### DIFF
--- a/web/src/components/RocketVisualization3D.tsx
+++ b/web/src/components/RocketVisualization3D.tsx
@@ -92,34 +92,38 @@ function RocketMesh({ state }: { state: SimulationState | null }) {
 
   return (
     <group ref={groupRef}>
-      {/* Rocket body - metallic red cylinder */}
-      <Cylinder args={[0.08, 0.08, 1.0, 16]} rotation={[Math.PI / 2, 0, 0]}>
-        <meshStandardMaterial color="#cc0000" metalness={0.7} roughness={0.3} />
-      </Cylinder>
+      {/* Inner group rotated so rocket points up (+Y) by default */}
+      {/* The outer group receives the physics quaternion */}
+      <group rotation={[0, 0, Math.PI / 2]}>
+        {/* Rocket body - metallic red cylinder */}
+        <Cylinder args={[0.08, 0.08, 1.0, 16]} rotation={[Math.PI / 2, 0, 0]}>
+          <meshStandardMaterial color="#cc0000" metalness={0.7} roughness={0.3} />
+        </Cylinder>
 
-      {/* Nose cone - white tip */}
-      <Cone
-        args={[0.08, 0.25, 16]}
-        position={[0.625, 0, 0]}
-        rotation={[0, 0, -Math.PI / 2]}
-      >
-        <meshStandardMaterial color="#ffffff" metalness={0.5} roughness={0.5} />
-      </Cone>
+        {/* Nose cone - white tip */}
+        <Cone
+          args={[0.08, 0.25, 16]}
+          position={[0.625, 0, 0]}
+          rotation={[0, 0, -Math.PI / 2]}
+        >
+          <meshStandardMaterial color="#ffffff" metalness={0.5} roughness={0.5} />
+        </Cone>
 
-      {/* Fins (4 fins at 90° intervals) */}
-      {[0, 90, 180, 270].map((angle, i) => {
-        const rad = (angle * Math.PI) / 180;
-        return (
-          <mesh
-            key={i}
-            position={[-0.4, Math.cos(rad) * 0.12, Math.sin(rad) * 0.12]}
-            rotation={[0, rad, 0]}
-          >
-            <boxGeometry args={[0.15, 0.02, 0.15]} />
-            <meshStandardMaterial color="#333333" metalness={0.8} roughness={0.2} />
-          </mesh>
-        );
-      })}
+        {/* Fins (4 fins at 90° intervals) */}
+        {[0, 90, 180, 270].map((angle, i) => {
+          const rad = (angle * Math.PI) / 180;
+          return (
+            <mesh
+              key={i}
+              position={[-0.4, Math.cos(rad) * 0.12, Math.sin(rad) * 0.12]}
+              rotation={[0, rad, 0]}
+            >
+              <boxGeometry args={[0.15, 0.02, 0.15]} />
+              <meshStandardMaterial color="#333333" metalness={0.8} roughness={0.2} />
+            </mesh>
+          );
+        })}
+      </group>
 
       {/* Velocity vector (green arrow) - positioned at rocket center */}
       {velocityArrowRef.current && <primitive object={velocityArrowRef.current} />}


### PR DESCRIPTION
## Summary
- Fixed rocket orientation so it points upward on the launch pad
- Added inner group rotation to transform rocket's local +X to world +Y
- Physics quaternion now correctly orients the rocket during flight

## Problem
The rocket mesh was built to point horizontally (+X axis), but it should be vertical when standing on the launch pad. This caused the rocket to appear laying on its side.

## Solution
Added an inner group with `rotation={[0, 0, Math.PI / 2]}` (90° around Z) so that:
- The rocket model points up by default
- The outer group receives the physics quaternion
- Combined rotation produces the correct visual orientation

Fixes #16

@claude please review this PR

## Test plan
- [ ] Initialize rocket simulation
- [ ] Verify rocket stands upright on the launch pad
- [ ] Start simulation and verify rocket tilts/flies correctly
- [ ] Verify velocity arrow points in the correct direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)