### PR TITLE
feat: Add WASM bindings for 2D grid simulation - no more mock physics

### DIFF
--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -13,9 +13,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Include directories (SOPOT is header-only)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-# Source files
+# Source files - both rocket and grid2d in single module
 set(SOURCES
     wasm_rocket.cpp
+    wasm_grid2d.cpp
 )
 
 # Emscripten-specific compiler flags

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -86,7 +86,7 @@ else
         OPT_FLAGS="-O0 -g -s ASSERTIONS=1 -s SAFE_HEAP=1"
     fi
 
-    # Build command
+    # Build command - includes both rocket and grid2d
     emcc -std=c++20 \
         $OPT_FLAGS \
         -lembind \
@@ -100,6 +100,7 @@ else
         -fexceptions \
         -I.. \
         wasm_rocket.cpp \
+        wasm_grid2d.cpp \
         -o sopot.js
 fi
 

--- a/wasm/wasm_grid2d.cpp
+++ b/wasm/wasm_grid2d.cpp
@@ -1,0 +1,359 @@
+/**
+ * WebAssembly wrapper for SOPOT 2D Grid simulation
+ *
+ * This file provides Emscripten embind bindings to expose the C++ 2D grid
+ * mass-spring simulation to JavaScript/TypeScript.
+ *
+ * All physics computations run in C++ - the frontend only visualizes.
+ */
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+#include "../physics/connected_masses/connectivity_matrix_2d.hpp"
+#include "../core/solver.hpp"
+#include <memory>
+#include <vector>
+#include <cmath>
+
+using namespace emscripten;
+using namespace sopot;
+using namespace sopot::connected_masses;
+
+/**
+ * Grid2DSimulator: JavaScript-friendly wrapper for 2D mass-spring grid
+ *
+ * Since the C++ grid uses compile-time template parameters, we support
+ * a few common grid sizes. The simulation runs entirely in C++.
+ */
+class Grid2DSimulator {
+private:
+    // Grid configuration
+    size_t m_rows{5};
+    size_t m_cols{5};
+    double m_mass{1.0};
+    double m_spacing{0.5};
+    double m_stiffness{50.0};
+    double m_damping{0.5};
+
+    // Simulation state
+    std::vector<double> m_state;
+    double m_time{0.0};
+    double m_dt{0.005};  // Default timestep: 5ms (smaller for stability)
+    bool m_initialized{false};
+
+    // We store derivatives function pointer based on grid size
+    enum class GridSize { G3x3, G4x4, G5x5, G6x6, G8x8, G10x10 };
+    GridSize m_grid_size{GridSize::G5x5};
+
+    // Template-based systems for different grid sizes
+    // Each is created on-demand when initialize() is called
+
+    // RK4 step function - works with any system
+    template<typename System>
+    void rk4Step(System& system, double dt) {
+        size_t n = m_state.size();
+
+        auto k1 = system.computeDerivatives(m_time, m_state);
+
+        std::vector<double> temp(n);
+        for (size_t i = 0; i < n; ++i) temp[i] = m_state[i] + 0.5 * dt * k1[i];
+        auto k2 = system.computeDerivatives(m_time + 0.5 * dt, temp);
+
+        for (size_t i = 0; i < n; ++i) temp[i] = m_state[i] + 0.5 * dt * k2[i];
+        auto k3 = system.computeDerivatives(m_time + 0.5 * dt, temp);
+
+        for (size_t i = 0; i < n; ++i) temp[i] = m_state[i] + dt * k3[i];
+        auto k4 = system.computeDerivatives(m_time + dt, temp);
+
+        for (size_t i = 0; i < n; ++i) {
+            m_state[i] += (dt / 6.0) * (k1[i] + 2.0*k2[i] + 2.0*k3[i] + k4[i]);
+        }
+
+        m_time += dt;
+    }
+
+    // Step functions for each grid size
+    void step3x3() {
+        static auto system = makeGrid2DSystem<double, 3, 3, false>(
+            m_mass, m_spacing, m_stiffness, m_damping);
+        rk4Step(system, m_dt);
+    }
+
+    void step4x4() {
+        static auto system = makeGrid2DSystem<double, 4, 4, false>(
+            m_mass, m_spacing, m_stiffness, m_damping);
+        rk4Step(system, m_dt);
+    }
+
+    void step5x5() {
+        static auto system = makeGrid2DSystem<double, 5, 5, false>(
+            m_mass, m_spacing, m_stiffness, m_damping);
+        rk4Step(system, m_dt);
+    }
+
+    void step6x6() {
+        static auto system = makeGrid2DSystem<double, 6, 6, false>(
+            m_mass, m_spacing, m_stiffness, m_damping);
+        rk4Step(system, m_dt);
+    }
+
+    void step8x8() {
+        static auto system = makeGrid2DSystem<double, 8, 8, false>(
+            m_mass, m_spacing, m_stiffness, m_damping);
+        rk4Step(system, m_dt);
+    }
+
+    void step10x10() {
+        static auto system = makeGrid2DSystem<double, 10, 10, false>(
+            m_mass, m_spacing, m_stiffness, m_damping);
+        rk4Step(system, m_dt);
+    }
+
+public:
+    Grid2DSimulator() = default;
+
+    //=========================================================================
+    // CONFIGURATION
+    //=========================================================================
+
+    /**
+     * Set grid dimensions (must be one of: 3x3, 4x4, 5x5, 6x6, 8x8, 10x10)
+     */
+    void setGridSize(int rows, int cols) {
+        if (rows != cols) {
+            throw std::runtime_error("Grid must be square (rows == cols)");
+        }
+
+        m_rows = rows;
+        m_cols = cols;
+
+        switch (rows) {
+            case 3:  m_grid_size = GridSize::G3x3; break;
+            case 4:  m_grid_size = GridSize::G4x4; break;
+            case 5:  m_grid_size = GridSize::G5x5; break;
+            case 6:  m_grid_size = GridSize::G6x6; break;
+            case 8:  m_grid_size = GridSize::G8x8; break;
+            case 10: m_grid_size = GridSize::G10x10; break;
+            default:
+                throw std::runtime_error("Grid size must be 3, 4, 5, 6, 8, or 10");
+        }
+    }
+
+    void setMass(double mass) { m_mass = mass; }
+    void setSpacing(double spacing) { m_spacing = spacing; }
+    void setStiffness(double stiffness) { m_stiffness = stiffness; }
+    void setDamping(double damping) { m_damping = damping; }
+    void setTimestep(double dt) { m_dt = dt; }
+
+    //=========================================================================
+    // INITIALIZATION
+    //=========================================================================
+
+    /**
+     * Initialize the grid simulation
+     */
+    void initialize() {
+        size_t num_masses = m_rows * m_cols;
+        size_t state_dim = num_masses * 4;  // x, y, vx, vy per mass
+
+        m_state.resize(state_dim);
+
+        // Initialize positions on a grid, velocities to zero
+        for (size_t r = 0; r < m_rows; ++r) {
+            for (size_t c = 0; c < m_cols; ++c) {
+                size_t idx = r * m_cols + c;
+                m_state[idx * 4 + 0] = c * m_spacing;  // x
+                m_state[idx * 4 + 1] = r * m_spacing;  // y
+                m_state[idx * 4 + 2] = 0.0;            // vx
+                m_state[idx * 4 + 3] = 0.0;            // vy
+            }
+        }
+
+        m_time = 0.0;
+        m_initialized = true;
+    }
+
+    /**
+     * Reset to initial state
+     */
+    void reset() {
+        initialize();
+    }
+
+    /**
+     * Perturb a mass at given row/col by displacement
+     */
+    void perturbMass(int row, int col, double dx, double dy) {
+        if (!m_initialized) return;
+        if (row < 0 || row >= static_cast<int>(m_rows)) return;
+        if (col < 0 || col >= static_cast<int>(m_cols)) return;
+
+        size_t idx = row * m_cols + col;
+        m_state[idx * 4 + 0] += dx;
+        m_state[idx * 4 + 1] += dy;
+    }
+
+    /**
+     * Perturb center mass (convenience)
+     */
+    void perturbCenter(double dx, double dy) {
+        int center_row = m_rows / 2;
+        int center_col = m_cols / 2;
+        perturbMass(center_row, center_col, dx, dy);
+    }
+
+    //=========================================================================
+    // SIMULATION
+    //=========================================================================
+
+    /**
+     * Advance simulation by one timestep
+     */
+    void step() {
+        if (!m_initialized) return;
+
+        switch (m_grid_size) {
+            case GridSize::G3x3:  step3x3(); break;
+            case GridSize::G4x4:  step4x4(); break;
+            case GridSize::G5x5:  step5x5(); break;
+            case GridSize::G6x6:  step6x6(); break;
+            case GridSize::G8x8:  step8x8(); break;
+            case GridSize::G10x10: step10x10(); break;
+        }
+    }
+
+    /**
+     * Step with custom dt
+     */
+    void stepWithDt(double dt) {
+        double old_dt = m_dt;
+        m_dt = dt;
+        step();
+        m_dt = old_dt;
+    }
+
+    //=========================================================================
+    // STATE QUERIES
+    //=========================================================================
+
+    double getTime() const { return m_time; }
+    int getRows() const { return m_rows; }
+    int getCols() const { return m_cols; }
+    bool isInitialized() const { return m_initialized; }
+
+    /**
+     * Get all positions as flat array [x0, y0, x1, y1, ...]
+     */
+    val getPositions() const {
+        if (!m_initialized) return val::array();
+
+        size_t num_masses = m_rows * m_cols;
+        std::vector<double> positions(num_masses * 2);
+
+        for (size_t i = 0; i < num_masses; ++i) {
+            positions[i * 2 + 0] = m_state[i * 4 + 0];  // x
+            positions[i * 2 + 1] = m_state[i * 4 + 1];  // y
+        }
+
+        return val::array(positions.begin(), positions.end());
+    }
+
+    /**
+     * Get all velocities as flat array [vx0, vy0, vx1, vy1, ...]
+     */
+    val getVelocities() const {
+        if (!m_initialized) return val::array();
+
+        size_t num_masses = m_rows * m_cols;
+        std::vector<double> velocities(num_masses * 2);
+
+        for (size_t i = 0; i < num_masses; ++i) {
+            velocities[i * 2 + 0] = m_state[i * 4 + 2];  // vx
+            velocities[i * 2 + 1] = m_state[i * 4 + 3];  // vy
+        }
+
+        return val::array(velocities.begin(), velocities.end());
+    }
+
+    /**
+     * Get full state as JavaScript object
+     */
+    val getState() const {
+        val result = val::object();
+        result.set("time", m_time);
+        result.set("rows", static_cast<int>(m_rows));
+        result.set("cols", static_cast<int>(m_cols));
+        result.set("positions", getPositions());
+        result.set("velocities", getVelocities());
+        return result;
+    }
+
+    /**
+     * Get position of specific mass
+     */
+    val getMassPosition(int row, int col) const {
+        val result = val::object();
+        if (!m_initialized) return result;
+        if (row < 0 || row >= static_cast<int>(m_rows)) return result;
+        if (col < 0 || col >= static_cast<int>(m_cols)) return result;
+
+        size_t idx = row * m_cols + col;
+        result.set("x", m_state[idx * 4 + 0]);
+        result.set("y", m_state[idx * 4 + 1]);
+        return result;
+    }
+
+    /**
+     * Compute total kinetic energy
+     */
+    double getKineticEnergy() const {
+        if (!m_initialized) return 0.0;
+
+        double ke = 0.0;
+        size_t num_masses = m_rows * m_cols;
+        for (size_t i = 0; i < num_masses; ++i) {
+            double vx = m_state[i * 4 + 2];
+            double vy = m_state[i * 4 + 3];
+            ke += 0.5 * m_mass * (vx*vx + vy*vy);
+        }
+        return ke;
+    }
+};
+
+//=============================================================================
+// EMSCRIPTEN BINDINGS
+//=============================================================================
+
+EMSCRIPTEN_BINDINGS(grid2d_module) {
+    class_<Grid2DSimulator>("Grid2DSimulator")
+        .constructor<>()
+
+        // Configuration
+        .function("setGridSize", &Grid2DSimulator::setGridSize)
+        .function("setMass", &Grid2DSimulator::setMass)
+        .function("setSpacing", &Grid2DSimulator::setSpacing)
+        .function("setStiffness", &Grid2DSimulator::setStiffness)
+        .function("setDamping", &Grid2DSimulator::setDamping)
+        .function("setTimestep", &Grid2DSimulator::setTimestep)
+
+        // Initialization
+        .function("initialize", &Grid2DSimulator::initialize)
+        .function("reset", &Grid2DSimulator::reset)
+        .function("perturbMass", &Grid2DSimulator::perturbMass)
+        .function("perturbCenter", &Grid2DSimulator::perturbCenter)
+
+        // Simulation
+        .function("step", &Grid2DSimulator::step)
+        .function("stepWithDt", &Grid2DSimulator::stepWithDt)
+
+        // State queries
+        .function("getTime", &Grid2DSimulator::getTime)
+        .function("getRows", &Grid2DSimulator::getRows)
+        .function("getCols", &Grid2DSimulator::getCols)
+        .function("isInitialized", &Grid2DSimulator::isInitialized)
+        .function("getPositions", &Grid2DSimulator::getPositions)
+        .function("getVelocities", &Grid2DSimulator::getVelocities)
+        .function("getState", &Grid2DSimulator::getState)
+        .function("getMassPosition", &Grid2DSimulator::getMassPosition)
+        .function("getKineticEnergy", &Grid2DSimulator::getKineticEnergy);
+}

--- a/web/src/hooks/useGrid2DSimulation.ts
+++ b/web/src/hooks/useGrid2DSimulation.ts
@@ -1,163 +1,14 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import type { SopotModule, Grid2DSimulator } from '../types/sopot';
 import type { Grid2DState } from '../components/Grid2DVisualization';
 
-// Mock simulation for now - will be replaced with actual WASM implementation
-interface Grid2DSimulator {
-  step: (dt: number) => void;
-  getState: () => Grid2DState;
-  reset: () => void;
-  destroy: () => void;
-}
-
-function createMockGrid2DSimulator(rows: number, cols: number): Grid2DSimulator {
-  let time = 0;
-  const numMasses = rows * cols;
-  const spacing = 0.5;
-
-  // Initialize positions in a grid
-  const positions: Array<{ x: number; y: number }> = [];
-  const velocities: Array<{ vx: number; vy: number }> = [];
-
-  for (let r = 0; r < rows; r++) {
-    for (let c = 0; c < cols; c++) {
-      positions.push({
-        x: c * spacing,
-        y: r * spacing,
-      });
-      velocities.push({ vx: 0, vy: 0 });
-    }
-  }
-
-  // Add initial perturbation to center
-  const centerIdx = Math.floor(rows / 2) * cols + Math.floor(cols / 2);
-  if (centerIdx < numMasses) {
-    positions[centerIdx].y += 0.3;
-  }
-
-  // Simple spring-mass dynamics
-  const mass = 0.5;
-  const stiffness = 30.0;
-  const damping = 0.8;
-  const restLength = spacing;
-
-  return {
-    step(dt: number) {
-      // Compute forces
-      const forces: Array<{ fx: number; fy: number }> = Array(numMasses)
-        .fill(null)
-        .map(() => ({ fx: 0, fy: 0 }));
-
-      // Horizontal springs
-      for (let r = 0; r < rows; r++) {
-        for (let c = 0; c < cols - 1; c++) {
-          const idx1 = r * cols + c;
-          const idx2 = r * cols + c + 1;
-
-          const dx = positions[idx2].x - positions[idx1].x;
-          const dy = positions[idx2].y - positions[idx1].y;
-          const length = Math.sqrt(dx * dx + dy * dy);
-
-          // Guard against zero-length springs to prevent NaN propagation
-          if (length < 1e-10) continue;
-
-          const extension = length - restLength;
-
-          const fx = (stiffness * extension * dx) / length;
-          const fy = (stiffness * extension * dy) / length;
-
-          // Damping
-          const dvx = velocities[idx2].vx - velocities[idx1].vx;
-          const dvy = velocities[idx2].vy - velocities[idx1].vy;
-          const relVel = (dvx * dx + dvy * dy) / length;
-          const dampingFx = (damping * relVel * dx) / length;
-          const dampingFy = (damping * relVel * dy) / length;
-
-          forces[idx1].fx += fx + dampingFx;
-          forces[idx1].fy += fy + dampingFy;
-          forces[idx2].fx -= fx + dampingFx;
-          forces[idx2].fy -= fy + dampingFy;
-        }
-      }
-
-      // Vertical springs
-      for (let r = 0; r < rows - 1; r++) {
-        for (let c = 0; c < cols; c++) {
-          const idx1 = r * cols + c;
-          const idx2 = (r + 1) * cols + c;
-
-          const dx = positions[idx2].x - positions[idx1].x;
-          const dy = positions[idx2].y - positions[idx1].y;
-          const length = Math.sqrt(dx * dx + dy * dy);
-
-          // Guard against zero-length springs to prevent NaN propagation
-          if (length < 1e-10) continue;
-
-          const extension = length - restLength;
-
-          const fx = (stiffness * extension * dx) / length;
-          const fy = (stiffness * extension * dy) / length;
-
-          // Damping
-          const dvx = velocities[idx2].vx - velocities[idx1].vx;
-          const dvy = velocities[idx2].vy - velocities[idx1].vy;
-          const relVel = (dvx * dx + dvy * dy) / length;
-          const dampingFx = (damping * relVel * dx) / length;
-          const dampingFy = (damping * relVel * dy) / length;
-
-          forces[idx1].fx += fx + dampingFx;
-          forces[idx1].fy += fy + dampingFy;
-          forces[idx2].fx -= fx + dampingFx;
-          forces[idx2].fy -= fy + dampingFy;
-        }
-      }
-
-      // Integrate
-      for (let i = 0; i < numMasses; i++) {
-        const ax = forces[i].fx / mass;
-        const ay = forces[i].fy / mass;
-
-        velocities[i].vx += ax * dt;
-        velocities[i].vy += ay * dt;
-
-        positions[i].x += velocities[i].vx * dt;
-        positions[i].y += velocities[i].vy * dt;
-      }
-
-      time += dt;
-    },
-
-    getState(): Grid2DState {
-      return {
-        time,
-        rows,
-        cols,
-        positions: [...positions],
-        velocities: [...velocities],
-      };
-    },
-
-    reset() {
-      time = 0;
-      for (let r = 0; r < rows; r++) {
-        for (let c = 0; c < cols; c++) {
-          const idx = r * cols + c;
-          positions[idx] = { x: c * spacing, y: r * spacing };
-          velocities[idx] = { vx: 0, vy: 0 };
-        }
-      }
-      // Re-add initial perturbation
-      if (centerIdx < numMasses) {
-        positions[centerIdx].y += 0.3;
-      }
-    },
-
-    destroy() {
-      // Cleanup if needed
-    },
-  };
-}
-
-export function useGrid2DSimulation(rows = 5, cols = 5) {
+/**
+ * Hook for 2D Grid simulation using WASM
+ *
+ * All physics computations run in C++ via WebAssembly.
+ * The frontend only handles visualization.
+ */
+export function useGrid2DSimulation(defaultRows = 5, defaultCols = 5) {
   const [isReady, setIsReady] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
@@ -165,74 +16,161 @@ export function useGrid2DSimulation(rows = 5, cols = 5) {
   const [currentState, setCurrentState] = useState<Grid2DState | null>(null);
   const [playbackSpeed, setPlaybackSpeed] = useState(1.0);
 
+  const moduleRef = useRef<SopotModule | null>(null);
   const simulatorRef = useRef<Grid2DSimulator | null>(null);
   const animationFrameRef = useRef<number | null>(null);
   const lastTimeRef = useRef<number>(0);
 
-  // Mark as ready immediately (or after WASM loads)
+  // Grid configuration
+  const [rows] = useState(defaultRows);
+  const [cols] = useState(defaultCols);
+
+  // Load WASM module
   useEffect(() => {
-    setIsReady(true);
+    const loadModule = async () => {
+      try {
+        // Check if module is available (loaded in index.html)
+        if (typeof window !== 'undefined' && window.createSopotModule) {
+          console.log('[Grid2D] Loading WASM module...');
+          const module = await window.createSopotModule();
+          moduleRef.current = module;
+
+          // Check if Grid2DSimulator is available
+          if (module.Grid2DSimulator) {
+            console.log('[Grid2D] WASM module loaded with Grid2DSimulator');
+            setIsReady(true);
+          } else {
+            console.warn('[Grid2D] Grid2DSimulator not found in WASM module');
+            setError('Grid2DSimulator not available. Rebuild WASM module.');
+          }
+        } else {
+          console.warn('[Grid2D] WASM module not loaded yet, retrying...');
+          // Retry after a short delay
+          setTimeout(loadModule, 500);
+        }
+      } catch (err) {
+        console.error('[Grid2D] Failed to load WASM module:', err);
+        setError('Failed to load physics engine');
+      }
+    };
+
+    loadModule();
   }, []);
 
-  const initialize = useCallback(() => {
+  // Convert WASM state to visualization state
+  const wasmToVizState = useCallback((simulator: Grid2DSimulator): Grid2DState => {
+    const wasmState = simulator.getState();
+    const positions: Array<{ x: number; y: number }> = [];
+    const velocities: Array<{ vx: number; vy: number }> = [];
+
+    const numMasses = wasmState.rows * wasmState.cols;
+    for (let i = 0; i < numMasses; i++) {
+      positions.push({
+        x: wasmState.positions[i * 2],
+        y: wasmState.positions[i * 2 + 1],
+      });
+      velocities.push({
+        vx: wasmState.velocities[i * 2],
+        vy: wasmState.velocities[i * 2 + 1],
+      });
+    }
+
+    return {
+      time: wasmState.time,
+      rows: wasmState.rows,
+      cols: wasmState.cols,
+      positions,
+      velocities,
+    };
+  }, []);
+
+  // Initialize simulation
+  const initialize = useCallback(async () => {
+    if (!moduleRef.current || !moduleRef.current.Grid2DSimulator) {
+      setError('WASM module not ready');
+      return;
+    }
+
     try {
-      console.log(`[Grid2D] Initializing ${rows}×${cols} grid simulation`);
-      simulatorRef.current = createMockGrid2DSimulator(rows, cols);
-      setCurrentState(simulatorRef.current.getState());
+      console.log(`[Grid2D] Initializing ${rows}x${cols} grid (C++ physics via WASM)`);
+
+      // Create new simulator
+      const simulator = new moduleRef.current.Grid2DSimulator();
+
+      // Configure grid
+      simulator.setGridSize(rows, cols);
+      simulator.setMass(1.0);
+      simulator.setSpacing(0.5);
+      simulator.setStiffness(50.0);
+      simulator.setDamping(0.5);
+      simulator.setTimestep(0.005);
+
+      // Initialize
+      simulator.initialize();
+
+      // Add initial perturbation to center
+      simulator.perturbCenter(0.0, 0.3);
+
+      simulatorRef.current = simulator;
+      setCurrentState(wasmToVizState(simulator));
       setIsInitialized(true);
       setError(null);
+
+      console.log('[Grid2D] Initialized successfully');
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to initialize');
+      const message = err instanceof Error ? err.message : 'Failed to initialize';
       console.error('[Grid2D] Initialization error:', err);
+      setError(message);
     }
-  }, [rows, cols]);
+  }, [rows, cols, wasmToVizState]);
 
+  // Reset simulation
   const reset = useCallback(() => {
-    if (!simulatorRef.current) return;
-
-    console.log('[Grid2D] Resetting simulation');
-    setIsRunning(false);
-
-    // Destroy and recreate to properly clean up resources
-    simulatorRef.current.destroy();
-    simulatorRef.current = null;
+    if (simulatorRef.current) {
+      setIsRunning(false);
+      simulatorRef.current = null;
+    }
     setCurrentState(null);
     setIsInitialized(false);
   }, []);
 
+  // Start simulation
   const start = useCallback(() => {
     if (!isInitialized) return;
-    console.log('[Grid2D] Starting simulation');
+    console.log('[Grid2D] Starting simulation (C++ physics)');
     setIsRunning(true);
     lastTimeRef.current = performance.now();
   }, [isInitialized]);
 
+  // Pause simulation
   const pause = useCallback(() => {
     console.log('[Grid2D] Pausing simulation');
     setIsRunning(false);
   }, []);
 
+  // Single step
   const step = useCallback(() => {
     if (!simulatorRef.current || isRunning) return;
 
-    const dt = 0.01; // Fixed timestep
-    simulatorRef.current.step(dt);
-    setCurrentState(simulatorRef.current.getState());
-  }, [isRunning]);
+    simulatorRef.current.step();
+    setCurrentState(wasmToVizState(simulatorRef.current));
+  }, [isRunning, wasmToVizState]);
 
   // Animation loop
   useEffect(() => {
     if (!isRunning || !simulatorRef.current) return;
 
     const animate = (currentTime: number) => {
-      const deltaTime = (currentTime - lastTimeRef.current) / 1000; // Convert to seconds
+      const deltaTime = (currentTime - lastTimeRef.current) / 1000;
       lastTimeRef.current = currentTime;
 
-      if (deltaTime > 0 && deltaTime < 0.1) {
-        // Limit max dt to avoid instability
-        const dt = Math.min(deltaTime * playbackSpeed, 0.05);
-        simulatorRef.current!.step(dt);
-        setCurrentState(simulatorRef.current!.getState());
+      if (deltaTime > 0 && deltaTime < 0.1 && simulatorRef.current) {
+        // Run multiple physics steps for stability
+        const numSteps = Math.max(1, Math.floor(deltaTime * playbackSpeed / 0.005));
+        for (let i = 0; i < Math.min(numSteps, 20); i++) {
+          simulatorRef.current.step();
+        }
+        setCurrentState(wasmToVizState(simulatorRef.current));
       }
 
       animationFrameRef.current = requestAnimationFrame(animate);
@@ -245,14 +183,12 @@ export function useGrid2DSimulation(rows = 5, cols = 5) {
         cancelAnimationFrame(animationFrameRef.current);
       }
     };
-  }, [isRunning, playbackSpeed]);
+  }, [isRunning, playbackSpeed, wasmToVizState]);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      if (simulatorRef.current) {
-        simulatorRef.current.destroy();
-      }
+      simulatorRef.current = null;
     };
   }, []);
 

--- a/web/src/types/sopot.d.ts
+++ b/web/src/types/sopot.d.ts
@@ -104,8 +104,54 @@ export interface RocketSimulator {
   getDebugInfo(): string;
 }
 
+/**
+ * 2D Grid simulation state
+ */
+export interface Grid2DWasmState {
+  time: number;
+  rows: number;
+  cols: number;
+  positions: number[];  // Flat array: [x0, y0, x1, y1, ...]
+  velocities: number[]; // Flat array: [vx0, vy0, vx1, vy1, ...]
+}
+
+/**
+ * 2D Grid Simulator - WASM wrapper for C++ physics
+ */
+export interface Grid2DSimulator {
+  // Configuration
+  setGridSize(rows: number, cols: number): void;
+  setMass(mass: number): void;
+  setSpacing(spacing: number): void;
+  setStiffness(stiffness: number): void;
+  setDamping(damping: number): void;
+  setTimestep(dt: number): void;
+
+  // Initialization
+  initialize(): void;
+  reset(): void;
+  perturbMass(row: number, col: number, dx: number, dy: number): void;
+  perturbCenter(dx: number, dy: number): void;
+
+  // Simulation
+  step(): void;
+  stepWithDt(dt: number): void;
+
+  // State queries
+  getTime(): number;
+  getRows(): number;
+  getCols(): number;
+  isInitialized(): boolean;
+  getPositions(): number[];
+  getVelocities(): number[];
+  getState(): Grid2DWasmState;
+  getMassPosition(row: number, col: number): { x: number; y: number };
+  getKineticEnergy(): number;
+}
+
 export interface SopotModule {
   RocketSimulator: new () => RocketSimulator;
+  Grid2DSimulator: new () => Grid2DSimulator;
 }
 
 export type CreateSopotModule = () => Promise<SopotModule>;


### PR DESCRIPTION
## Summary
- Replaced JavaScript mock physics with actual C++ physics via WASM
- All physics now runs in C++ - frontend only visualizes
- Clear separation of concerns: C++ physics -> WASM -> TypeScript visualization

## Problem
The 2D grid simulation was using a JavaScript mock implementation instead of the actual C++ SOPOT physics. This violated the core principle that:
- **C++ handles all physics** (zero duplication)
- **Frontend only visualizes**

## Solution
Created proper WASM bindings for the 2D grid simulation:

### New Files
- `wasm/wasm_grid2d.cpp`: WASM wrapper exposing `Grid2DSimulator` class
  - Uses actual SOPOT physics (`makeGrid2DSystem`)
  - RK4 integration (same as C++ tests)
  - Supports grid sizes: 3x3, 4x4, 5x5, 6x6, 8x8, 10x10

### Modified Files
- `wasm/CMakeLists.txt`: Added wasm_grid2d.cpp to build
- `wasm/build.sh`: Added wasm_grid2d.cpp to direct build
- `web/src/types/sopot.d.ts`: Added Grid2DSimulator TypeScript interface
- `web/src/hooks/useGrid2DSimulation.ts`: **Completely rewritten**
  - Removed all JavaScript physics code
  - Uses WASM Grid2DSimulator for physics

## Architecture (After)
```
C++ (SOPOT physics)  →  WASM  →  TypeScript (visualization only)
   Grid2DSimulator         ↑         useGrid2DSimulation hook
   RK4 integration         │         Grid2DVisualization component
   Spring-mass physics     │
                      no physics here
```

Fixes #15

@claude please review this PR

## Test plan
- [ ] Rebuild WASM module: `cd wasm && ./build.sh Release`
- [ ] Copy to web: `cp sopot.js sopot.wasm ../web/public/`
- [ ] Start web app: `cd ../web && npm run dev`
- [ ] Select "2D Grid" simulation type
- [ ] Click Initialize - should work with WASM physics
- [ ] Run simulation - grid should oscillate physically
- [ ] Verify console shows "C++ physics via WASM" messages

## Note
Requires rebuilding the WASM module to include Grid2DSimulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)