### PR TITLE
fix: Add missing buttonPrimary style to ControlPanel

### DIFF
--- a/web/src/components/ControlPanel.tsx
+++ b/web/src/components/ControlPanel.tsx
@@ -359,6 +359,11 @@ const styles = {
     opacity: 0.3,
     cursor: 'not-allowed',
   },
+  buttonPrimary: {
+    background: 'linear-gradient(135deg, #0066cc 0%, #004499 100%)',
+    border: '1px solid rgba(0, 212, 255, 0.3)',
+    boxShadow: '0 0 12px rgba(0, 102, 204, 0.3)',
+  },
   sliderContainer: {
     display: 'flex',
     alignItems: 'center',


### PR DESCRIPTION
The TypeScript build was failing because the ControlPanel component
was referencing styles.buttonPrimary (line 153) but this style was
not defined in the styles object.

Added buttonPrimary style matching the .btn-primary CSS class with:
- Blue gradient background
- Cyan border
- Glow effect shadow

This fixes the web build TypeScript error:
"Property 'buttonPrimary' does not exist on type..."