### PR TITLE
fix: Add WASM build testing to CI and fix deployment triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,53 @@ on:
     branches: [ master, main ]
 
 jobs:
+  wasm-build:
+    name: WebAssembly Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Emscripten
+      uses: mymindstorm/setup-emsdk@v14
+      with:
+        version: '3.1.51'  # Match production version
+
+    - name: Verify Emscripten installation
+      run: emcc --version
+
+    - name: Build WebAssembly module
+      run: |
+        cd wasm
+        ./build.sh Release
+
+    - name: Validate WASM output
+      run: |
+        # Check files exist
+        if [ ! -f wasm/sopot.js ]; then
+          echo "ERROR: sopot.js not found"
+          exit 1
+        fi
+
+        if [ ! -f wasm/sopot.wasm ]; then
+          echo "ERROR: sopot.wasm not found"
+          exit 1
+        fi
+
+        # Check files are not empty
+        if [ ! -s wasm/sopot.js ]; then
+          echo "ERROR: sopot.js is empty"
+          exit 1
+        fi
+
+        if [ ! -s wasm/sopot.wasm ]; then
+          echo "ERROR: sopot.wasm is empty"
+          exit 1
+        fi
+
+        echo "✅ WASM build successful"
+        ls -lh wasm/sopot.js wasm/sopot.wasm
+
   build:
     name: ${{ matrix.os }} - ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'web/**'
       - 'wasm/**'
+      - 'core/**'
+      - 'physics/**'
+      - 'rocket/**'
+      - 'io/**'
       - '.github/workflows/deploy-github-pages.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
Fixes critical gap where WASM build errors were not caught during PR review.

Changes:
1. Add wasm-build job to CI workflow
   - Installs Emscripten 3.1.51 (matches production)
   - Builds WASM module using build.sh
   - Validates output files exist and are not empty
   - Runs on all PRs in parallel with native builds

2. Expand deployment workflow triggers
   - Added core/**, physics/**, rocket/**, io/** paths
   - Ensures C++ framework changes trigger deployment
   - Previously only web/** and wasm/** triggered deployment

Impact:
- WASM compilation errors now caught in PR phase (not production)
- Framework changes automatically trigger deployment
- Prevents production failures from undetected WASM issues

Root cause: Native C++ compilers (GCC/Clang/MSVC) accepted code that
Emscripten rejected due to template depth limits, feature support, etc.