### PR TITLE
fix: Auto-open controls panel on mobile for immediate simulation access

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,7 +20,9 @@ function App() {
   const [simulationType, setSimulationType] = useState<SimulationType>('rocket');
   const [showVelocities, setShowVelocities] = useState(false);
   const [showGrid, setShowGrid] = useState(true);
-  const [mobilePanel, setMobilePanel] = useState<MobilePanel>(null);
+  const [mobilePanel, setMobilePanel] = useState<MobilePanel>(
+    window.innerWidth < 768 ? 'controls' : null
+  );
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
   // Note: Both hooks are instantiated to maintain React hook call order,


### PR DESCRIPTION
The mobile UX redesign accidentally removed the auto-open behavior for
the controls panel on mobile devices. This caused users to see only the
visualization with no obvious way to select simulation type or start the
simulation.

Fixed by restoring the conditional initialization of mobilePanel state:
- Mobile (< 768px): Auto-opens to 'controls' panel
- Desktop: Remains closed (null)

This ensures mobile users immediately see:
- Simulation type selector (rocket/grid2d)
- Configuration options
- Initialize and start controls

Location: web/src/App.tsx:23-25