### PR TITLE
feat: Improve Grid2D simulation with center of mass preservation and physics controls

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -294,6 +294,12 @@ function App() {
                   showGrid={showGrid}
                   onShowVelocitiesChange={setShowVelocities}
                   onShowGridChange={setShowGrid}
+                  mass={gridSim.mass}
+                  stiffness={gridSim.stiffness}
+                  damping={gridSim.damping}
+                  onMassChange={gridSim.setMass}
+                  onStiffnessChange={gridSim.setStiffness}
+                  onDampingChange={gridSim.setDamping}
                 />
               ) : (
                 <InvertedPendulumControlPanel
@@ -450,6 +456,12 @@ function App() {
                 showGrid={showGrid}
                 onShowVelocitiesChange={setShowVelocities}
                 onShowGridChange={setShowGrid}
+                mass={gridSim.mass}
+                stiffness={gridSim.stiffness}
+                damping={gridSim.damping}
+                onMassChange={gridSim.setMass}
+                onStiffnessChange={gridSim.setStiffness}
+                onDampingChange={gridSim.setDamping}
               />
             ) : (
               <InvertedPendulumControlPanel

--- a/web/src/components/Grid2DControlPanel.tsx
+++ b/web/src/components/Grid2DControlPanel.tsx
@@ -15,6 +15,13 @@ interface Grid2DControlPanelProps {
   showGrid?: boolean;
   onShowVelocitiesChange?: (show: boolean) => void;
   onShowGridChange?: (show: boolean) => void;
+  // Physics parameters
+  mass?: number;
+  stiffness?: number;
+  damping?: number;
+  onMassChange?: (mass: number) => void;
+  onStiffnessChange?: (stiffness: number) => void;
+  onDampingChange?: (damping: number) => void;
 }
 
 export function Grid2DControlPanel({
@@ -33,6 +40,12 @@ export function Grid2DControlPanel({
   showGrid = true,
   onShowVelocitiesChange,
   onShowGridChange,
+  mass = 1.0,
+  stiffness = 50.0,
+  damping = 0.15,
+  onMassChange,
+  onStiffnessChange,
+  onDampingChange,
 }: Grid2DControlPanelProps) {
   const playbackSpeeds = [0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0];
 
@@ -136,6 +149,65 @@ export function Grid2DControlPanel({
               {speed}×
             </button>
           ))}
+        </div>
+      </div>
+
+      {/* Physics Parameters */}
+      <div style={styles.section}>
+        <h3 style={styles.sectionTitle}>Physics Parameters</h3>
+        <p style={styles.warningText}>
+          Change these before initialization
+        </p>
+
+        <div style={styles.parameterControl}>
+          <label style={styles.parameterLabel}>
+            <span style={styles.parameterName}>Mass (kg)</span>
+            <span style={styles.parameterValue}>{mass.toFixed(2)}</span>
+          </label>
+          <input
+            type="range"
+            min="0.1"
+            max="5.0"
+            step="0.1"
+            value={mass}
+            onChange={(e) => onMassChange?.(parseFloat(e.target.value))}
+            disabled={isInitialized}
+            style={styles.slider}
+          />
+        </div>
+
+        <div style={styles.parameterControl}>
+          <label style={styles.parameterLabel}>
+            <span style={styles.parameterName}>Stiffness (N/m)</span>
+            <span style={styles.parameterValue}>{stiffness.toFixed(1)}</span>
+          </label>
+          <input
+            type="range"
+            min="10"
+            max="200"
+            step="5"
+            value={stiffness}
+            onChange={(e) => onStiffnessChange?.(parseFloat(e.target.value))}
+            disabled={isInitialized}
+            style={styles.slider}
+          />
+        </div>
+
+        <div style={styles.parameterControl}>
+          <label style={styles.parameterLabel}>
+            <span style={styles.parameterName}>Damping (N·s/m)</span>
+            <span style={styles.parameterValue}>{damping.toFixed(2)}</span>
+          </label>
+          <input
+            type="range"
+            min="0.0"
+            max="2.0"
+            step="0.05"
+            value={damping}
+            onChange={(e) => onDampingChange?.(parseFloat(e.target.value))}
+            disabled={isInitialized}
+            style={styles.slider}
+          />
         </div>
       </div>
 
@@ -300,5 +372,32 @@ const styles = {
     color: 'var(--text-secondary)',
     lineHeight: '1.6',
     marginBottom: '10px',
+  },
+  warningText: {
+    fontSize: '12px',
+    color: 'var(--accent-amber)',
+    marginBottom: '15px',
+    fontStyle: 'italic' as const,
+  },
+  parameterControl: {
+    marginBottom: '15px',
+  },
+  parameterLabel: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginBottom: '5px',
+  },
+  parameterName: {
+    fontSize: '13px',
+    color: 'var(--text-primary)',
+  },
+  parameterValue: {
+    fontSize: '13px',
+    color: 'var(--accent-cyan)',
+    fontWeight: 'bold' as const,
+  },
+  slider: {
+    width: '100%',
+    cursor: 'pointer',
   },
 };

--- a/web/src/hooks/useGrid2DSimulation.ts
+++ b/web/src/hooks/useGrid2DSimulation.ts
@@ -26,6 +26,11 @@ export function useGrid2DSimulation(defaultRows = 5, defaultCols = 5) {
   const [rows] = useState(defaultRows);
   const [cols] = useState(defaultCols);
 
+  // Physics parameters
+  const [mass, setMass] = useState(1.0);
+  const [stiffness, setStiffness] = useState(50.0);
+  const [damping, setDamping] = useState(0.15);
+
   // Load WASM module (same approach as useRocketSimulation)
   useEffect(() => {
     let mounted = true;
@@ -81,12 +86,22 @@ export function useGrid2DSimulation(defaultRows = 5, defaultCols = 5) {
       });
     }
 
+    // Get center of mass and energy values
+    const centerOfMass = simulator.getCenterOfMass();
+    const kineticEnergy = simulator.getKineticEnergy();
+    const potentialEnergy = simulator.getPotentialEnergy();
+    const totalEnergy = simulator.getTotalEnergy();
+
     return {
       time: wasmState.time,
       rows: wasmState.rows,
       cols: wasmState.cols,
       positions,
       velocities,
+      centerOfMass,
+      kineticEnergy,
+      potentialEnergy,
+      totalEnergy,
     };
   }, []);
 
@@ -105,10 +120,10 @@ export function useGrid2DSimulation(defaultRows = 5, defaultCols = 5) {
 
       // Configure grid
       simulator.setGridSize(rows, cols);
-      simulator.setMass(1.0);
+      simulator.setMass(mass);
       simulator.setSpacing(0.5);
-      simulator.setStiffness(50.0);
-      simulator.setDamping(0.15);
+      simulator.setStiffness(stiffness);
+      simulator.setDamping(damping);
       simulator.setTimestep(0.005);
 
       // Initialize
@@ -128,7 +143,7 @@ export function useGrid2DSimulation(defaultRows = 5, defaultCols = 5) {
       console.error('[Grid2D] Initialization error:', err);
       setError(message);
     }
-  }, [rows, cols, wasmToVizState]);
+  }, [rows, cols, mass, stiffness, damping, wasmToVizState]);
 
   // Reset simulation
   const reset = useCallback(() => {
@@ -213,12 +228,18 @@ export function useGrid2DSimulation(defaultRows = 5, defaultCols = 5) {
     error,
     currentState,
     playbackSpeed,
+    mass,
+    stiffness,
+    damping,
     initialize,
     start,
     pause,
     reset,
     step,
     setPlaybackSpeed,
+    setMass,
+    setStiffness,
+    setDamping,
     perturbMass,
   };
 }

--- a/web/src/types/sopot.d.ts
+++ b/web/src/types/sopot.d.ts
@@ -147,8 +147,9 @@ export interface Grid2DSimulator {
   getState(): Grid2DWasmState;
   getMassPosition(row: number, col: number): { x: number; y: number };
   getKineticEnergy(): number;
+  getPotentialEnergy(): number;
+  getTotalEnergy(): number;
   getCenterOfMass(): { x: number; y: number };
-  getTotalMomentum(): { px: number; py: number };
 }
 
 /**


### PR DESCRIPTION
This commit enhances the 2D grid mass-spring simulation with several improvements:

**Physics Calculations (C++):**
- Add center of mass calculation (getCenterOfMass)
- Add potential energy calculation for all springs (getPotentialEnergy)
- Add total energy calculation (getTotalEnergy = KE + PE)
- Expose new methods through Emscripten bindings

**Visualization Improvements:**
- Fix screen transformation to preserve center of mass position
  - Changed from min-based to center-based coordinate transformation
  - Grid now stays centered on screen as it oscillates
- Add cyan center of mass indicator dot with label
- Add energy display (KE, PE, and total E) with color coding
- Update TypeScript types to include new state properties

**UI Controls:**
- Add physics parameter controls (mass, stiffness, damping)
- Parameters adjustable via sliders before initialization
- Display current parameter values
- Add warning text indicating parameters must be set before init

**Technical Details:**
- Transform logic now uses bounding box center instead of minimum
- Energy is calculated from spring extensions: PE = 0.5 * k * (L - L0)^2
- Center of mass: CoM = Σ(m_i * r_i) / Σ(m_i)
- All calculations done in C++ for performance

This addresses the center of mass drift issue and provides better
control over simulation physics parameters.