### PR TITLE
fix: Dynamic mass sizing for large grids and mobile grid size selector

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -461,6 +461,8 @@ function App() {
                 showGrid={showGrid}
                 onShowVelocitiesChange={setShowVelocities}
                 onShowGridChange={setShowGrid}
+                gridSize={gridSim.gridSize}
+                onGridSizeChange={gridSim.setGridSize}
                 mass={gridSim.mass}
                 stiffness={gridSim.stiffness}
                 damping={gridSim.damping}

--- a/web/src/components/Grid2DVisualization.tsx
+++ b/web/src/components/Grid2DVisualization.tsx
@@ -6,13 +6,27 @@ const TOUCH_RADIUS_PX = 30; // pixels - hit detection radius for touch targets
 const TOUCH_FEEDBACK_DURATION_MS = 200; // milliseconds - visual feedback duration
 const PERTURB_STRENGTH_M = 0.2; // meters - vertical perturbation strength
 const CANVAS_PADDING_PX = 50; // pixels - padding around visualization area
-const MASS_RADIUS_NORMAL_PX = 4; // pixels - normal mass render radius
-const MASS_RADIUS_TOUCHED_PX = 6; // pixels - touched mass render radius
-const MASS_GLOW_RADIUS_NORMAL_PX = 8; // pixels - normal mass glow radius
-const MASS_GLOW_RADIUS_TOUCHED_PX = 12; // pixels - touched mass glow radius
 const MASS_GLOW_OPACITY_NORMAL = 0.3; // opacity for normal glow
 const MASS_GLOW_OPACITY_TOUCHED = 0.6; // opacity for touched glow
 const DIAGONAL_EDGE_OPACITY = 0.6; // opacity for diagonal edges in triangular grid
+
+// Dynamic mass sizing based on grid size
+function getMassRadius(gridSize: number, isTouched: boolean): number {
+  // Scale mass radius inversely with grid size
+  // Small grids (5-10): 4-5px, Medium (20): 3px, Large (50-100): 1.5-2px
+  const baseRadius = gridSize <= 10 ? 4 : gridSize <= 20 ? 3 : gridSize <= 50 ? 2 : 1.5;
+  return isTouched ? baseRadius * 1.5 : baseRadius;
+}
+
+function getGlowRadius(gridSize: number, isTouched: boolean): number {
+  const massRadius = getMassRadius(gridSize, isTouched);
+  return massRadius * 2;
+}
+
+function getSpringLineWidth(gridSize: number): number {
+  // Thinner lines for larger grids
+  return gridSize <= 20 ? 1 : 0.5;
+}
 
 export interface Grid2DState {
   time: number;
@@ -223,7 +237,7 @@ export function Grid2DVisualization({
     // Draw grid edges (springs)
     if (showGrid) {
       ctx.strokeStyle = getCSSVariable('--bg-tertiary');
-      ctx.lineWidth = 1;
+      ctx.lineWidth = getSpringLineWidth(state.rows);
 
       const { rows, cols } = state;
 
@@ -260,7 +274,7 @@ export function Grid2DVisualization({
       // Diagonal edges (only for triangular grid)
       if (gridType === 'triangle') {
         ctx.strokeStyle = getCSSVariable('--bg-tertiary');
-        ctx.lineWidth = 1;
+        ctx.lineWidth = getSpringLineWidth(state.rows);
         ctx.globalAlpha = DIAGONAL_EDGE_OPACITY; // Make diagonals slightly transparent
 
         for (let r = 0; r < rows - 1; r++) {
@@ -331,30 +345,33 @@ export function Grid2DVisualization({
       });
     }
 
-    // Draw masses as circles
+    // Draw masses as circles (size scales with grid size)
+    const gridSize = state.rows;
     positions.forEach((pos, idx) => {
       const x = toCanvasX(pos.x);
       const y = toCanvasY(pos.y);
       const isTouched = idx === touchedMass;
 
-      // Glow effect (larger if touched)
-      const redColor = getCSSVariable('--accent-red');
-      const rgb = redColor.match(/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i);
-      const opacity = isTouched ? MASS_GLOW_OPACITY_TOUCHED : MASS_GLOW_OPACITY_NORMAL;
-      if (rgb) {
-        ctx.fillStyle = `rgba(${parseInt(rgb[1], 16)}, ${parseInt(rgb[2], 16)}, ${parseInt(rgb[3], 16)}, ${opacity})`;
-      } else {
-        ctx.fillStyle = `rgba(255, 59, 59, ${opacity})`;
+      // Glow effect (larger if touched) - skip glow for very large grids
+      if (gridSize <= 50) {
+        const redColor = getCSSVariable('--accent-red');
+        const rgb = redColor.match(/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i);
+        const opacity = isTouched ? MASS_GLOW_OPACITY_TOUCHED : MASS_GLOW_OPACITY_NORMAL;
+        if (rgb) {
+          ctx.fillStyle = `rgba(${parseInt(rgb[1], 16)}, ${parseInt(rgb[2], 16)}, ${parseInt(rgb[3], 16)}, ${opacity})`;
+        } else {
+          ctx.fillStyle = `rgba(255, 59, 59, ${opacity})`;
+        }
+        ctx.beginPath();
+        const glowRadius = getGlowRadius(gridSize, isTouched);
+        ctx.arc(x, y, glowRadius, 0, 2 * Math.PI);
+        ctx.fill();
       }
-      ctx.beginPath();
-      const glowRadius = isTouched ? MASS_GLOW_RADIUS_TOUCHED_PX : MASS_GLOW_RADIUS_NORMAL_PX;
-      ctx.arc(x, y, glowRadius, 0, 2 * Math.PI);
-      ctx.fill();
 
       // Mass point
       ctx.fillStyle = getCSSVariable('--accent-red');
       ctx.beginPath();
-      const massRadius = isTouched ? MASS_RADIUS_TOUCHED_PX : MASS_RADIUS_NORMAL_PX;
+      const massRadius = getMassRadius(gridSize, isTouched);
       ctx.arc(x, y, massRadius, 0, 2 * Math.PI);
       ctx.fill();
     });


### PR DESCRIPTION
## Summary

- Fix visualization for 100x100 grids - masses were too large and overlapping
- Fix mobile version - grid size selector was missing

## Changes

### Visualization improvements (`Grid2DVisualization.tsx`)
- Mass radius now scales dynamically with grid size:
  - Small grids (5-10): 4px
  - Medium grids (20): 3px  
  - Large grids (50): 2px
  - Very large grids (100): 1.5px
- Spring line width scales down for large grids (0.5px for >20x20)
- Skip glow effect for 100x100 grids to reduce visual clutter and improve performance

### Mobile fix (`App.tsx`)
- Add missing `gridSize` and `onGridSizeChange` props to the mobile BottomSheet's Grid2DControlPanel

## Test plan
- [ ] Test 100x100 grid visualization - masses should be small dots, not overlapping circles
- [ ] Test mobile view - grid size selector should now appear and work
- [ ] Verify smaller grids (5x5, 10x10) still look good with larger mass circles

🤖 Generated with [Claude Code](https://claude.com/claude-code)