### PR TITLE
feat: Add optional steep repulsion force to prevent mass interpenetration

### DIFF
--- a/physics/connected_masses/indexed_spring.hpp
+++ b/physics/connected_masses/indexed_spring.hpp
@@ -5,6 +5,7 @@
 #include "indexed_tags.hpp"
 #include <string>
 #include <stdexcept>
+#include <cmath>
 
 namespace sopot::connected_masses {
 
@@ -32,6 +33,8 @@ private:
     double m_stiffness;      // Spring constant k (N/m)
     double m_rest_length;    // Rest length L0 (m)
     double m_damping;        // Damping coefficient c (N·s/m)
+    double m_min_distance;   // Collision radius (m) - steep repulsion below this
+    double m_repulsion_stiffness;  // Repulsion strength (N/m)
     std::string m_name;
 
 public:
@@ -41,16 +44,24 @@ public:
      * @param stiffness Spring constant k (N/m) - must be positive
      * @param rest_length Natural length L0 (m) - must be non-negative
      * @param damping Damping coefficient c (N·s/m), default 0 - must be non-negative
+     * @param min_distance Collision radius (m) - steep repulsion below this distance
+     *                     Default: 10% of rest_length (or 0.01 if rest_length is 0)
+     * @param repulsion_stiffness Strength of repulsion force (N/m)
+     *                            Default: 10x stiffness
      * @throws std::invalid_argument if parameters are invalid
      */
     explicit IndexedSpring(
         double stiffness,
         double rest_length,
-        double damping = 0.0
+        double damping = 0.0,
+        double min_distance = -1.0,
+        double repulsion_stiffness = -1.0
     )
         : m_stiffness(stiffness)
         , m_rest_length(rest_length)
         , m_damping(damping)
+        , m_min_distance(min_distance)  // Default 0 = no repulsion
+        , m_repulsion_stiffness(repulsion_stiffness > 0.0 ? repulsion_stiffness : 10.0 * stiffness)
         , m_name("Spring" + std::to_string(Index1) + "_" + std::to_string(Index2))
     {
         if (stiffness <= 0.0) {
@@ -91,6 +102,7 @@ public:
      * @brief Compute force on mass 1 (registry-aware)
      *
      * Force pulls mass 1 toward mass 2 when extended.
+     * Includes steep repulsion when masses get too close.
      */
     template<typename Registry>
     T compute(
@@ -98,6 +110,8 @@ public:
         std::span<const T> state,
         const Registry& registry
     ) const {
+        using std::sqrt;
+
         // Query positions of both masses
         T x1 = registry.template computeFunction<typename TagSet1::Position>(state);
         T x2 = registry.template computeFunction<typename TagSet2::Position>(state);
@@ -116,6 +130,21 @@ public:
             T relative_velocity = v1 - v2;
             T damping_force = -T(m_damping) * relative_velocity;
             spring_force += damping_force;
+        }
+
+        // Steep repulsion when masses get too close (only if min_distance > 0)
+        // Uses inverse formula: F_repulsion = k_rep * (r_min/r - 1) when |x1-x2| < r_min
+        if (m_min_distance > 0.0) {
+            T dx = x1 - x2;
+            T distance = sqrt(dx * dx);  // Works with autodiff
+            if (value_of(distance) < m_min_distance) {
+                T distance_safe = distance < T(1e-10) ? T(1e-10) : distance;
+                // Direction: +1 if x1 > x2, -1 if x1 < x2
+                T direction = dx / distance_safe;
+                // Repulsion pushes masses apart
+                T repulsion_magnitude = T(m_repulsion_stiffness) * (T(m_min_distance) / distance_safe - T(1.0));
+                spring_force += repulsion_magnitude * direction;
+            }
         }
 
         return spring_force;

--- a/physics/connected_masses/indexed_spring_2d.hpp
+++ b/physics/connected_masses/indexed_spring_2d.hpp
@@ -45,6 +45,8 @@ private:
     double m_stiffness;     // k (N/m)
     double m_rest_length;   // L0 (m)
     double m_damping;       // c (N·s/m)
+    double m_min_distance;  // Collision radius (m) - steep repulsion below this
+    double m_repulsion_stiffness;  // Repulsion strength (N/m)
     std::string m_name;
 
 public:
@@ -54,16 +56,24 @@ public:
      * @param stiffness Spring constant k (N/m) - must be non-negative
      * @param rest_length Natural length L0 (m) - must be positive
      * @param damping Damping coefficient c (N·s/m) - must be non-negative
+     * @param min_distance Collision radius (m) - steep repulsion below this distance
+     *                     Default: 10% of rest_length
+     * @param repulsion_stiffness Strength of repulsion force (N/m)
+     *                            Default: 10x stiffness
      * @throws std::invalid_argument if parameters are invalid
      */
     explicit IndexedSpring2D(
         double stiffness,
         double rest_length,
-        double damping = 0.0
+        double damping = 0.0,
+        double min_distance = -1.0,
+        double repulsion_stiffness = -1.0
     )
         : m_stiffness(stiffness)
         , m_rest_length(rest_length)
         , m_damping(damping)
+        , m_min_distance(min_distance)  // Default 0 = no repulsion
+        , m_repulsion_stiffness(repulsion_stiffness > 0.0 ? repulsion_stiffness : 10.0 * stiffness)
         , m_name("Spring2D_" + std::to_string(I) + "_" + std::to_string(J))
     {
         if (stiffness < 0.0) {
@@ -128,6 +138,16 @@ public:
 
         // Spring force magnitude (Hooke's law + damping)
         T force_magnitude = T(m_stiffness) * extension + T(m_damping) * relative_velocity;
+
+        // Steep repulsion when masses get too close (only if min_distance > 0)
+        // Uses inverse formula: F_repulsion = k_rep * (r_min/r - 1) when r < r_min
+        // This creates a force that increases steeply as r approaches 0
+        if (m_min_distance > 0.0 && value_of(length) < m_min_distance) {
+            // Repulsion force magnitude (negative = pushes apart)
+            // The (r_min/r - 1) term goes to infinity as r -> 0
+            T repulsion = -T(m_repulsion_stiffness) * (T(m_min_distance) / length_safe - T(1.0));
+            force_magnitude += repulsion;
+        }
 
         // Force vector on mass I (points from I toward J when spring is stretched)
         std::array<T, 2> force_on_i = {

--- a/physics/coupled_oscillator/spring.hpp
+++ b/physics/coupled_oscillator/spring.hpp
@@ -37,6 +37,8 @@ private:
     double m_stiffness;      // Spring constant k [N/m]
     double m_rest_length;    // Natural length L0 [m]
     double m_damping;        // Damping coefficient c [N·s/m]
+    double m_min_distance;   // Collision radius [m] - steep repulsion below this
+    double m_repulsion_stiffness;  // Repulsion strength [N/m]
     std::string m_name;
 
 public:
@@ -44,10 +46,14 @@ public:
         double stiffness,
         double rest_length = 1.0,
         double damping = 0.0,
-        std::string name = "spring"
+        std::string name = "spring",
+        double min_distance = -1.0,
+        double repulsion_stiffness = -1.0
     ) : m_stiffness(stiffness)
       , m_rest_length(rest_length)
       , m_damping(damping)
+      , m_min_distance(min_distance)  // Default 0 = no repulsion
+      , m_repulsion_stiffness(repulsion_stiffness > 0.0 ? repulsion_stiffness : 10.0 * stiffness)
       , m_name(std::move(name)) {
         if (stiffness <= 0.0) {
             throw std::invalid_argument("Spring stiffness must be positive");
@@ -79,13 +85,19 @@ public:
         return x1 - x2 - T(m_rest_length);
     }
 
-    // Force on mass 1: F1 = -k * extension - c * (v1 - v2)
+    // Force on mass 1: F1 = -k * extension - c * (v1 - v2) + repulsion
     template<typename Registry>
     T compute(typename TagSet1::Force, std::span<const T> state, const Registry& registry) const {
+        using std::sqrt;
+        using std::abs;
+
         T x1 = registry.template computeFunction<typename TagSet1::Position>(state);
         T x2 = registry.template computeFunction<typename TagSet2::Position>(state);
+
+        // Signed extension (original formula, maintains backward compatibility)
         T extension = x1 - x2 - T(m_rest_length);
 
+        // Spring force: F = -k * extension (restoring force)
         T spring_force = -T(m_stiffness) * extension;
 
         // Add damping if present
@@ -93,7 +105,22 @@ public:
             T v1 = registry.template computeFunction<typename TagSet1::Velocity>(state);
             T v2 = registry.template computeFunction<typename TagSet2::Velocity>(state);
             T damping_force = -T(m_damping) * (v1 - v2);
-            return spring_force + damping_force;
+            spring_force += damping_force;
+        }
+
+        // Steep repulsion when masses get too close (only if min_distance > 0)
+        // Uses inverse formula: F_repulsion = k_rep * (r_min/r - 1) when |x1-x2| < r_min
+        if (m_min_distance > 0.0) {
+            T dx = x1 - x2;
+            T distance = sqrt(dx * dx);  // Works with autodiff
+            if (value_of(distance) < m_min_distance) {
+            T distance_safe = distance < T(1e-10) ? T(1e-10) : distance;
+            // Direction: +1 if x1 > x2, -1 if x1 < x2
+            T direction = dx / distance_safe;
+                // Repulsion pushes masses apart
+                T repulsion_magnitude = T(m_repulsion_stiffness) * (T(m_min_distance) / distance_safe - T(1.0));
+                spring_force += repulsion_magnitude * direction;
+            }
         }
 
         return spring_force;
@@ -138,8 +165,14 @@ using Spring12 = Spring<mass1, mass2, T>;
 //=============================================================================
 
 template<Scalar T = double>
-Spring12<T> createSpring(double stiffness, double rest_length = 1.0, double damping = 0.0) {
-    return Spring12<T>(stiffness, rest_length, damping, "spring");
+Spring12<T> createSpring(
+    double stiffness,
+    double rest_length = 1.0,
+    double damping = 0.0,
+    double min_distance = -1.0,
+    double repulsion_stiffness = -1.0
+) {
+    return Spring12<T>(stiffness, rest_length, damping, "spring", min_distance, repulsion_stiffness);
 }
 
 } // namespace sopot::physics::coupled


### PR DESCRIPTION
Add configurable repulsion parameters to all spring types:
- min_distance: collision radius below which repulsion activates
- repulsion_stiffness: strength of the repulsive force

When enabled (min_distance > 0), applies inverse formula:
F_repulsion = k_rep * (r_min/r - 1) when r < r_min

This prevents instabilities when masses get too close in simulations,
particularly useful for 2D grid/cloth simulations.

Repulsion is opt-in (disabled by default) to maintain backward
compatibility with existing simulations.