### PR TITLE
Generalize cart-pole to a six inverted pendulum chain

### DIFF
--- a/physics/control/cart_n_pendulum.hpp
+++ b/physics/control/cart_n_pendulum.hpp
@@ -1,0 +1,362 @@
+#pragma once
+
+#include "core/typed_component.hpp"
+#include "core/scalar.hpp"
+#include "control_tags.hpp"
+#include <string>
+#include <stdexcept>
+#include <array>
+#include <cmath>
+
+namespace sopot::control {
+
+/**
+ * @brief Cart with an inverted N-link pendulum chain.
+ *
+ * This is the generalization of the classic "cart-pole" problem to an
+ * arbitrary number of serially-connected pendulum links balanced on a
+ * single actuated cart. With @p NLinks == 1 it is the textbook cart-pole;
+ * with @p NLinks == 2 it reproduces the cart-double-pendulum; the project
+ * configures it with @p NLinks == 6 for the six-pendulum demonstration.
+ *
+ * Generalized coordinates: q = [x, θ₁, θ₂, …, θ_N]
+ *   - x:   cart position (m)
+ *   - θᵢ:  angle of link i measured from vertical (rad), 0 = upright
+ *
+ * Full state vector (size 2·(N+1)):
+ *   [x, θ₁ … θ_N, ẋ, ω₁ … ω_N]
+ *
+ * Control input: horizontal force F applied to the cart (N).
+ *
+ * Each link i carries a point mass mᵢ at its tip. Positions (relative to the
+ * ground frame, y pointing up, θ = 0 upright):
+ *   xᵢ = x + Σ_{j≤i} Lⱼ sin θⱼ
+ *   yᵢ =     Σ_{j≤i} Lⱼ cos θⱼ
+ *
+ * Equations of motion are derived from the Lagrangian and assembled as
+ *   M(q) q̈ = rhs(q, q̇, F)
+ * with the (N+1)×(N+1) symmetric mass matrix and right-hand side
+ *   M₀₀          = m_cart + Σ mᵢ
+ *   M₀ⱼ = Mⱼ₀    = M̄ⱼ Lⱼ cos θⱼ
+ *   Mⱼₖ          = M̄_{max(j,k)} Lⱼ Lₖ cos(θⱼ − θₖ)
+ *   rhs₀         = F + Σ M̄ⱼ Lⱼ sin θⱼ ωⱼ²
+ *   rhsⱼ         = M̄ⱼ g Lⱼ sin θⱼ − Σₖ M̄_{max(j,k)} Lⱼ Lₖ sin(θⱼ − θₖ) ωₖ²
+ * where M̄ⱼ = Σ_{i≥j} mᵢ is the "tail mass" carried by joint j.
+ * The (N+1)×(N+1) linear system is solved with Gaussian elimination, which
+ * works for both plain `double` and autodiff `Dual` scalar types.
+ */
+template<size_t NLinks, Scalar T = double>
+class CartNPendulum final : public TypedComponent<2 * (NLinks + 1), T> {
+public:
+    static_assert(NLinks >= 1, "CartNPendulum requires at least one link");
+
+    static constexpr size_t num_links = NLinks;
+    static constexpr size_t num_dof   = NLinks + 1;   // cart + N angles
+    static constexpr size_t num_state = 2 * num_dof;  // positions + velocities
+
+    using Base = TypedComponent<num_state, T>;
+    using typename Base::LocalState;
+    using typename Base::LocalDerivative;
+
+private:
+    double m_cart_mass;                       // mc: cart mass (kg)
+    std::array<double, NLinks> m_mass;        // mᵢ: point mass at link i tip (kg)
+    std::array<double, NLinks> m_length;      // Lᵢ: length of link i (m)
+    double m_gravity;                         // g: gravity (m/s²)
+
+    std::array<double, num_state> m_initial_state;  // [x, θ…, ẋ, ω…]
+
+    // Control input (set externally by the controller before each derivative eval)
+    mutable T m_control_force = T(0.0);
+
+    std::string m_name;
+
+    // Indices into the state / generalized-coordinate vectors.
+    static constexpr size_t idxX()        { return 0; }
+    static constexpr size_t idxTheta(size_t link) { return 1 + link; }
+    static constexpr size_t idxXDot()     { return num_dof; }
+    static constexpr size_t idxOmega(size_t link) { return num_dof + 1 + link; }
+
+public:
+    /**
+     * @brief Construct an N-link cart pendulum.
+     * @param cart_mass     Cart mass (kg)
+     * @param link_masses   Point mass at each link tip (kg)
+     * @param link_lengths  Length of each link (m)
+     * @param gravity       Gravitational acceleration (m/s²)
+     * @param initial_state Full initial state [x, θ₁…θ_N, ẋ, ω₁…ω_N]
+     */
+    CartNPendulum(
+        double cart_mass,
+        const std::array<double, NLinks>& link_masses,
+        const std::array<double, NLinks>& link_lengths,
+        double gravity = 9.81,
+        const std::array<double, num_state>& initial_state = {}
+    )
+        : m_cart_mass(cart_mass)
+        , m_mass(link_masses)
+        , m_length(link_lengths)
+        , m_gravity(gravity)
+        , m_initial_state(initial_state)
+        , m_name("CartNPendulum")
+    {
+        if (cart_mass <= 0.0) {
+            throw std::invalid_argument("Cart mass must be positive");
+        }
+        for (size_t i = 0; i < NLinks; ++i) {
+            if (m_mass[i] <= 0.0) {
+                throw std::invalid_argument("All link masses must be positive");
+            }
+            if (m_length[i] <= 0.0) {
+                throw std::invalid_argument("All link lengths must be positive");
+            }
+        }
+    }
+
+    // Set control input (force on cart)
+    void setControlForce(T force) const { m_control_force = force; }
+    T getControlForce() const { return m_control_force; }
+
+    LocalState getInitialLocalState() const {
+        LocalState s;
+        for (size_t i = 0; i < num_state; ++i) {
+            s[i] = T(m_initial_state[i]);
+        }
+        return s;
+    }
+
+    std::string_view getComponentType() const { return "CartNPendulum"; }
+    std::string_view getComponentName() const { return m_name; }
+
+    /**
+     * @brief Tail mass M̄ⱼ = Σ_{i≥j} mᵢ carried by joint of link @p link.
+     */
+    double tailMass(size_t link) const {
+        double sum = 0.0;
+        for (size_t i = link; i < NLinks; ++i) sum += m_mass[i];
+        return sum;
+    }
+
+    /**
+     * @brief Compute state derivatives via the Euler-Lagrange equations.
+     */
+    template<typename Registry>
+    LocalDerivative derivatives(
+        T /*t*/,
+        std::span<const T> local,
+        std::span<const T> /*global*/,
+        const Registry& /*registry*/
+    ) const {
+        using std::sin; using std::cos;
+        using sopot::sin; using sopot::cos;
+
+        const T g = T(m_gravity);
+        const T F = m_control_force;
+
+        // Cache trig of each link angle.
+        std::array<T, NLinks> s{}, c{};
+        std::array<T, NLinks> omega{};
+        for (size_t i = 0; i < NLinks; ++i) {
+            T theta = local[idxTheta(i)];
+            s[i] = sin(theta);
+            c[i] = cos(theta);
+            omega[i] = local[idxOmega(i)];
+        }
+
+        // Tail masses (constant per configuration).
+        std::array<double, NLinks> Mtail{};
+        for (size_t i = 0; i < NLinks; ++i) Mtail[i] = tailMass(i);
+
+        // Assemble the symmetric (N+1)×(N+1) mass matrix M and rhs vector.
+        std::array<std::array<T, num_dof>, num_dof> M{};
+        std::array<T, num_dof> rhs{};
+
+        // Cart row/column.
+        T total_mass = T(m_cart_mass);
+        for (size_t i = 0; i < NLinks; ++i) total_mass = total_mass + T(m_mass[i]);
+        M[0][0] = total_mass;
+
+        rhs[0] = F;
+        for (size_t a = 0; a < NLinks; ++a) {
+            T coupling = T(Mtail[a]) * T(m_length[a]) * c[a];
+            M[0][idxTheta(a)] = coupling;
+            M[idxTheta(a)][0] = coupling;
+            rhs[0] = rhs[0] + T(Mtail[a]) * T(m_length[a]) * s[a] * omega[a] * omega[a];
+        }
+
+        // Angle rows/columns.
+        for (size_t a = 0; a < NLinks; ++a) {
+            // Gravity term.
+            T rhs_a = T(Mtail[a]) * g * T(m_length[a]) * s[a];
+
+            for (size_t b = 0; b < NLinks; ++b) {
+                size_t mx = (a > b) ? a : b;
+                T cab = c[a] * c[b] + s[a] * s[b];                 // cos(θa − θb)
+                M[idxTheta(a)][idxTheta(b)] =
+                    T(Mtail[mx]) * T(m_length[a]) * T(m_length[b]) * cab;
+
+                if (b != a) {
+                    T sab = s[a] * c[b] - c[a] * s[b];             // sin(θa − θb)
+                    rhs_a = rhs_a - T(Mtail[mx]) * T(m_length[a]) * T(m_length[b])
+                                    * sab * omega[b] * omega[b];
+                }
+            }
+            rhs[idxTheta(a)] = rhs_a;
+        }
+
+        // Solve M · accel = rhs (Gaussian elimination with partial pivoting).
+        std::array<T, num_dof> accel = solveLinearSystem(M, rhs);
+
+        // Assemble derivative: position rates = velocities, velocity rates = accel.
+        LocalDerivative deriv;
+        deriv[idxX()] = local[idxXDot()];
+        for (size_t i = 0; i < NLinks; ++i) {
+            deriv[idxTheta(i)] = local[idxOmega(i)];
+        }
+        deriv[idxXDot()] = accel[0];
+        for (size_t i = 0; i < NLinks; ++i) {
+            deriv[idxOmega(i)] = accel[idxTheta(i)];
+        }
+        return deriv;
+    }
+
+    // =========================================================================
+    // State queries (work on the global state span)
+    // =========================================================================
+
+    T cartPosition(std::span<const T> state) const { return this->getGlobalState(state, idxX()); }
+    T cartVelocity(std::span<const T> state) const { return this->getGlobalState(state, idxXDot()); }
+
+    T linkAngle(size_t link, std::span<const T> state) const {
+        return this->getGlobalState(state, idxTheta(link));
+    }
+    T linkAngularVelocity(size_t link, std::span<const T> state) const {
+        return this->getGlobalState(state, idxOmega(link));
+    }
+
+    /**
+     * @brief Cartesian [x, y] position of the tip of link @p link.
+     */
+    std::array<T, 2> linkTipPosition(size_t link, std::span<const T> state) const {
+        using std::sin; using std::cos;
+        using sopot::sin; using sopot::cos;
+        T x = this->getGlobalState(state, idxX());
+        T px = x;
+        T py = T(0.0);
+        for (size_t i = 0; i <= link; ++i) {
+            T theta = this->getGlobalState(state, idxTheta(i));
+            px = px + T(m_length[i]) * sin(theta);
+            py = py + T(m_length[i]) * cos(theta);
+        }
+        return {px, py};
+    }
+
+    T kineticEnergy(std::span<const T> state) const {
+        using std::sin; using std::cos;
+        using sopot::sin; using sopot::cos;
+
+        T xdot = this->getGlobalState(state, idxXDot());
+
+        // Cart kinetic energy.
+        T KE = T(0.5) * T(m_cart_mass) * xdot * xdot;
+
+        // Each point mass: accumulate the chain velocity contributions.
+        T vx_accum = xdot;  // running Σ Lⱼ cosθⱼ ωⱼ added to ẋ
+        T vy_accum = T(0.0);
+        for (size_t i = 0; i < NLinks; ++i) {
+            T theta = this->getGlobalState(state, idxTheta(i));
+            T omega = this->getGlobalState(state, idxOmega(i));
+            vx_accum = vx_accum + T(m_length[i]) * cos(theta) * omega;
+            vy_accum = vy_accum - T(m_length[i]) * sin(theta) * omega;
+            KE = KE + T(0.5) * T(m_mass[i]) * (vx_accum * vx_accum + vy_accum * vy_accum);
+        }
+        return KE;
+    }
+
+    T potentialEnergy(std::span<const T> state) const {
+        using std::cos;
+        using sopot::cos;
+        T g = T(m_gravity);
+        T height_accum = T(0.0);
+        T PE = T(0.0);
+        for (size_t i = 0; i < NLinks; ++i) {
+            T theta = this->getGlobalState(state, idxTheta(i));
+            height_accum = height_accum + T(m_length[i]) * cos(theta);
+            PE = PE + T(m_mass[i]) * g * height_accum;
+        }
+        return PE;
+    }
+
+    T totalEnergy(std::span<const T> state) const {
+        return kineticEnergy(state) + potentialEnergy(state);
+    }
+
+    // -------------------------------------------------------------------------
+    // Minimal tag-based interface (cart only; angles are queried per-index above)
+    // -------------------------------------------------------------------------
+    T compute(cart::Position, std::span<const T> state) const { return cartPosition(state); }
+    T compute(cart::Velocity, std::span<const T> state) const { return cartVelocity(state); }
+    T compute(cart::Mass, std::span<const T> /*state*/) const { return T(m_cart_mass); }
+
+    // Controller interface
+    T compute(controller::ControlInput, std::span<const T> /*state*/) const { return m_control_force; }
+
+    // Parameter accessors
+    double getCartMass() const { return m_cart_mass; }
+    double getMass(size_t link) const { return m_mass[link]; }
+    double getLength(size_t link) const { return m_length[link]; }
+    const std::array<double, NLinks>& getMasses() const { return m_mass; }
+    const std::array<double, NLinks>& getLengths() const { return m_length; }
+    double getGravity() const { return m_gravity; }
+
+private:
+    /**
+     * @brief Solve A·x = b for the dense (N+1)×(N+1) system using Gaussian
+     *        elimination with partial pivoting. Templated on the scalar type
+     *        so it works with both `double` and autodiff `Dual` numbers
+     *        (pivot selection compares the underlying real values).
+     */
+    static std::array<T, num_dof> solveLinearSystem(
+        std::array<std::array<T, num_dof>, num_dof> A,
+        std::array<T, num_dof> b
+    ) {
+        for (size_t col = 0; col < num_dof; ++col) {
+            // Partial pivot: largest |value| in this column.
+            size_t pivot = col;
+            double best = std::abs(value_of(A[col][col]));
+            for (size_t row = col + 1; row < num_dof; ++row) {
+                double mag = std::abs(value_of(A[row][col]));
+                if (mag > best) { best = mag; pivot = row; }
+            }
+            if (best < 1e-15) {
+                throw std::runtime_error("CartNPendulum: mass matrix is singular; cannot solve for accelerations.");
+            }
+            if (pivot != col) {
+                std::swap(A[col], A[pivot]);
+                std::swap(b[col], b[pivot]);
+            }
+
+            // Eliminate below the pivot.
+            for (size_t row = col + 1; row < num_dof; ++row) {
+                T factor = A[row][col] / A[col][col];
+                for (size_t j = col; j < num_dof; ++j) {
+                    A[row][j] = A[row][j] - factor * A[col][j];
+                }
+                b[row] = b[row] - factor * b[col];
+            }
+        }
+
+        // Back substitution.
+        std::array<T, num_dof> x{};
+        for (size_t i = num_dof; i-- > 0; ) {
+            T sum = b[i];
+            for (size_t j = i + 1; j < num_dof; ++j) {
+                sum = sum - A[i][j] * x[j];
+            }
+            x[i] = sum / A[i][i];
+        }
+        return x;
+    }
+};
+
+} // namespace sopot::control

--- a/physics/control/lqr.hpp
+++ b/physics/control/lqr.hpp
@@ -555,4 +555,129 @@ inline std::pair<
     return {A, B};
 }
 
+/**
+ * @brief Linearize the cart-N-pendulum about the upright equilibrium.
+ *
+ * State (size 2·(N+1)): [x, θ₁ … θ_N, ẋ, ω₁ … ω_N].
+ * Input: scalar force F on the cart.
+ *
+ * At the upright equilibrium (all θ = 0, all velocities = 0) the mass matrix
+ * is constant and the only first-order term in the right-hand side is the
+ * gravity torque g_j = M̄ⱼ g Lⱼ θⱼ (the Coriolis terms are second order in
+ * velocity and vanish). Hence
+ *   q̈ = M₀⁻¹ ( G q_angles + e₀ F )
+ * which directly populates the lower blocks of A and B.
+ *
+ * @tparam NLinks Number of pendulum links.
+ * @param mc      Cart mass.
+ * @param masses  Point mass at each link tip.
+ * @param lengths Length of each link.
+ * @param g       Gravity.
+ * @return Pair (A, B) with A of size (2N+2)×(2N+2) and B of size (2N+2)×1.
+ */
+template<size_t NLinks>
+std::pair<
+    std::array<std::array<double, 2 * (NLinks + 1)>, 2 * (NLinks + 1)>,
+    std::array<std::array<double, 1>, 2 * (NLinks + 1)>
+> linearizeCartNPendulum(
+    double mc,
+    const std::array<double, NLinks>& masses,
+    const std::array<double, NLinks>& lengths,
+    double g
+) {
+    constexpr size_t NDof  = NLinks + 1;       // generalized coordinates
+    constexpr size_t NFull = 2 * NDof;         // full linear state size
+
+    auto tail_mass = [&](size_t link) {
+        double sum = 0.0;
+        for (size_t i = link; i < NLinks; ++i) sum += masses[i];
+        return sum;
+    };
+
+    // Mass matrix at equilibrium (all cos = 1).
+    std::array<std::array<double, NDof>, NDof> M{};
+    double total = mc;
+    for (size_t i = 0; i < NLinks; ++i) total += masses[i];
+    M[0][0] = total;
+    for (size_t a = 0; a < NLinks; ++a) {
+        double coupling = tail_mass(a) * lengths[a];
+        M[0][a + 1] = coupling;
+        M[a + 1][0] = coupling;
+    }
+    for (size_t a = 0; a < NLinks; ++a) {
+        for (size_t b = 0; b < NLinks; ++b) {
+            size_t mx = (a > b) ? a : b;
+            M[a + 1][b + 1] = tail_mass(mx) * lengths[a] * lengths[b];
+        }
+    }
+
+    // Invert M via Gauss-Jordan elimination with partial pivoting.
+    std::array<std::array<double, NDof>, NDof> Minv{};
+    {
+        std::array<std::array<double, 2 * NDof>, NDof> aug{};
+        for (size_t i = 0; i < NDof; ++i) {
+            for (size_t j = 0; j < NDof; ++j) aug[i][j] = M[i][j];
+            aug[i][NDof + i] = 1.0;
+        }
+        for (size_t col = 0; col < NDof; ++col) {
+            size_t pivot = col;
+            double best = std::abs(aug[col][col]);
+            for (size_t row = col + 1; row < NDof; ++row) {
+                if (std::abs(aug[row][col]) > best) { best = std::abs(aug[row][col]); pivot = row; }
+            }
+            if (best < 1e-15) {
+                throw std::runtime_error("linearizeCartNPendulum: mass matrix is singular");
+            }
+            std::swap(aug[col], aug[pivot]);
+            double diag = aug[col][col];
+            for (size_t j = 0; j < 2 * NDof; ++j) aug[col][j] /= diag;
+            for (size_t row = 0; row < NDof; ++row) {
+                if (row == col) continue;
+                double factor = aug[row][col];
+                for (size_t j = 0; j < 2 * NDof; ++j) aug[row][j] -= factor * aug[col][j];
+            }
+        }
+        for (size_t i = 0; i < NDof; ++i)
+            for (size_t j = 0; j < NDof; ++j)
+                Minv[i][j] = aug[i][NDof + j];
+    }
+
+    // Gravity Jacobian G (NDof×NDof): only diagonal angle entries.
+    std::array<std::array<double, NDof>, NDof> G{};
+    for (size_t a = 0; a < NLinks; ++a) {
+        G[a + 1][a + 1] = tail_mass(a) * g * lengths[a];
+    }
+
+    // MinvG = M⁻¹ G  -> lower-left block of A (accelerations vs. coordinates).
+    std::array<std::array<double, NDof>, NDof> MinvG{};
+    for (size_t i = 0; i < NDof; ++i) {
+        for (size_t j = 0; j < NDof; ++j) {
+            double s = 0.0;
+            for (size_t k = 0; k < NDof; ++k) s += Minv[i][k] * G[k][j];
+            MinvG[i][j] = s;
+        }
+    }
+
+    // Assemble A and B.
+    std::array<std::array<double, NFull>, NFull> A{};
+    std::array<std::array<double, 1>, NFull> B{};
+
+    // Upper-right identity: q̇ part of the state.
+    for (size_t i = 0; i < NDof; ++i) {
+        A[i][NDof + i] = 1.0;
+    }
+    // Lower-left: M⁻¹ G mapping coordinates to accelerations.
+    for (size_t i = 0; i < NDof; ++i) {
+        for (size_t j = 0; j < NDof; ++j) {
+            A[NDof + i][j] = MinvG[i][j];
+        }
+    }
+    // Input column: M⁻¹ e₀ (force enters only the cart equation).
+    for (size_t i = 0; i < NDof; ++i) {
+        B[NDof + i][0] = Minv[i][0];
+    }
+
+    return {A, B};
+}
+
 } // namespace sopot::control

--- a/physics/control/state_feedback_controller.hpp
+++ b/physics/control/state_feedback_controller.hpp
@@ -203,4 +203,65 @@ inline InvertedDoublePendulumController InvertedDoublePendulumController::create
     return InvertedDoublePendulumController(lqr.getGain());
 }
 
+/**
+ * @brief LQR state-feedback controller for the cart-N-pendulum.
+ *
+ * Generalizes InvertedDoublePendulumController to an arbitrary number of
+ * links. The state has size 2·(N+1) = [x, θ₁…θ_N, ẋ, ω₁…ω_N] and there is a
+ * single control input (force on the cart).
+ *
+ * @tparam NLinks Number of pendulum links.
+ */
+template<size_t NLinks>
+class CartNPendulumController : public StateFeedbackController<2 * (NLinks + 1), 1> {
+public:
+    static constexpr size_t state_dim = 2 * (NLinks + 1);
+    using Base = StateFeedbackController<state_dim, 1>;
+    using typename Base::GainMatrix;
+
+    explicit CartNPendulumController(const GainMatrix& K) : Base(K) {}
+
+    /**
+     * @brief Linearize about the upright equilibrium and solve the LQR problem.
+     *
+     * @param mc       Cart mass.
+     * @param masses   Point mass at each link tip.
+     * @param lengths  Length of each link.
+     * @param g        Gravity.
+     * @param q_diag   Diagonal of the state weight matrix Q (size 2·(N+1)).
+     * @param r        Scalar control weight R.
+     */
+    static CartNPendulumController createWithLQR(
+        double mc,
+        const std::array<double, NLinks>& masses,
+        const std::array<double, NLinks>& lengths,
+        double g,
+        const std::array<double, state_dim>& q_diag,
+        double r,
+        double riccati_dt = 0.002
+    ) {
+        auto [A, B] = linearizeCartNPendulum<NLinks>(mc, masses, lengths, g);
+
+        std::array<std::array<double, state_dim>, state_dim> Q{};
+        for (size_t i = 0; i < state_dim; ++i) {
+            Q[i][i] = q_diag[i];
+        }
+
+        std::array<std::array<double, 1>, 1> R{};
+        R[0][0] = r;
+
+        LQR<state_dim, 1> lqr;
+        lqr.solve(A, B, Q, R, riccati_dt);
+
+        return CartNPendulumController(lqr.getGain());
+    }
+
+    /**
+     * @brief Compute the scalar control force for a full state vector.
+     */
+    double computeForce(const std::array<double, state_dim>& state) const {
+        return this->compute(state)[0];
+    }
+};
+
 } // namespace sopot::control

--- a/tests/inverted_pendulum_test.cpp
+++ b/tests/inverted_pendulum_test.cpp
@@ -1,14 +1,18 @@
 /**
  * @file inverted_pendulum_test.cpp
- * @brief Tests for the cart-double-pendulum control system
+ * @brief Tests for the cart-N-pendulum control system (configured for 6 links)
  *
  * Verifies:
- * 1. Plant dynamics are correct (uncontrolled fall)
- * 2. LQR gain computation works
- * 3. Closed-loop stabilization works
+ * 1. Generic N-link plant reproduces the analytic double pendulum (N=2)
+ * 2. Plant creation and energy computation for the 6-link chain
+ * 3. Uncontrolled dynamics (the 6 pendulums fall)
+ * 4. Linearization structure about the upright equilibrium
+ * 5. LQR gain computation for the 14-state system
+ * 6. Closed-loop stabilization of all 6 inverted pendulums
  */
 
 #include "physics/control/cart_double_pendulum.hpp"
+#include "physics/control/cart_n_pendulum.hpp"
 #include "physics/control/lqr.hpp"
 #include "physics/control/state_feedback_controller.hpp"
 #include "core/typed_component.hpp"
@@ -24,6 +28,10 @@ using namespace sopot::control;
 constexpr double EPSILON = 1e-6;
 constexpr double PI = 3.14159265358979323846;
 
+// Number of pendulum links balanced on the cart.
+constexpr size_t NLINKS = 6;
+constexpr size_t NSTATE = 2 * (NLINKS + 1);  // 14
+
 bool approx_equal(double a, double b, double eps = EPSILON) {
     return std::abs(a - b) < eps;
 }
@@ -32,177 +40,194 @@ void test_passed(const char* name) {
     std::cout << "  [PASS] " << name << std::endl;
 }
 
-// ============================================================================
-// Test: Plant creation and initial state
-// ============================================================================
-void test_plant_creation() {
-    std::cout << "Test: Plant creation..." << std::endl;
+// Default six-link configuration used across the controlled tests.
+struct Config {
+    double mc = 2.0;
+    double g = 9.81;
+    std::array<double, NLINKS> masses;
+    std::array<double, NLINKS> lengths;
+    Config() {
+        masses.fill(0.1);
+        lengths.fill(0.3);
+    }
+};
 
-    // Create cart-double-pendulum with typical parameters
-    CartDoublePendulum<double> plant(
-        1.0,   // cart mass (kg)
-        0.5,   // mass 1 (kg)
-        0.5,   // mass 2 (kg)
-        0.5,   // length 1 (m)
-        0.5,   // length 2 (m)
-        9.81,  // gravity (m/s²)
-        0.0,   // initial x
-        0.1,   // initial θ₁ (small angle from vertical)
-        0.05,  // initial θ₂
-        0.0,   // initial ẋ
-        0.0,   // initial ω₁
-        0.0    // initial ω₂
-    );
-
-    auto state = plant.getInitialLocalState();
-
-    assert(approx_equal(state[0], 0.0));   // x
-    assert(approx_equal(state[1], 0.1));   // θ₁
-    assert(approx_equal(state[2], 0.05));  // θ₂
-    assert(approx_equal(state[3], 0.0));   // ẋ
-    assert(approx_equal(state[4], 0.0));   // ω₁
-    assert(approx_equal(state[5], 0.0));   // ω₂
-
-    test_passed("Plant creation");
+std::array<double, NSTATE> lqrWeights() {
+    std::array<double, NSTATE> q{};
+    q[0] = 1.0;                                  // cart position
+    for (size_t i = 1; i <= NLINKS; ++i) q[i] = 200.0;          // link angles
+    q[NLINKS + 1] = 1.0;                         // cart velocity
+    for (size_t i = NLINKS + 2; i < NSTATE; ++i) q[i] = 10.0;   // link rates
+    return q;
 }
 
 // ============================================================================
-// Test: Energy computation
+// Test: Generic plant matches the analytic double pendulum (N=2)
+// ============================================================================
+void test_matches_double_pendulum() {
+    std::cout << "Test: Generic N=2 matches CartDoublePendulum..." << std::endl;
+
+    double mc = 1.0, m1 = 0.5, m2 = 0.4, L1 = 0.5, L2 = 0.6, g = 9.81;
+    CartDoublePendulum<double> ref(mc, m1, m2, L1, L2, g,
+                                   0.3, 0.2, -0.1, 0.5, 0.4, -0.3);
+    CartNPendulum<2, double> gen(mc, {m1, m2}, {L1, L2}, g,
+                                 {0.3, 0.2, -0.1, 0.5, 0.4, -0.3});
+    ref.setControlForce(2.0);
+    gen.setControlForce(2.0);
+
+    std::vector<double> st = {0.3, 0.2, -0.1, 0.5, 0.4, -0.3};
+    std::span<const double> sp(st);
+    TypedRegistry<double> reg{};
+
+    auto dref = ref.derivatives(0.0, sp, sp, reg);
+    auto dgen = gen.derivatives(0.0, sp, sp, reg);
+    for (size_t i = 0; i < 6; ++i) {
+        assert(approx_equal(dref[i], dgen[i], 1e-9));
+    }
+
+    // Energies must agree as well.
+    assert(approx_equal(ref.compute(system::KineticEnergy{}, st), gen.kineticEnergy(sp), 1e-9));
+    assert(approx_equal(ref.compute(system::PotentialEnergy{}, st), gen.potentialEnergy(sp), 1e-9));
+
+    test_passed("Generic N=2 matches CartDoublePendulum");
+}
+
+// ============================================================================
+// Test: Plant creation and initial state (6 links)
+// ============================================================================
+void test_plant_creation() {
+    std::cout << "Test: Six-link plant creation..." << std::endl;
+
+    Config cfg;
+    std::array<double, NSTATE> x0{};
+    for (size_t i = 1; i <= NLINKS; ++i) x0[i] = 0.05 * static_cast<double>(i);
+
+    CartNPendulum<NLINKS, double> plant(cfg.mc, cfg.masses, cfg.lengths, cfg.g, x0);
+    auto state = plant.getInitialLocalState();
+
+    assert(state.size == NSTATE);
+    for (size_t i = 0; i < NSTATE; ++i) {
+        assert(approx_equal(state[i], x0[i]));
+    }
+    test_passed("Six-link plant creation");
+}
+
+// ============================================================================
+// Test: Energy computation at the upright equilibrium
 // ============================================================================
 void test_energy_computation() {
     std::cout << "Test: Energy computation..." << std::endl;
 
-    // Create plant at upright equilibrium
-    CartDoublePendulum<double> plant(
-        1.0, 0.5, 0.5, 0.5, 0.5, 9.81,
-        0.0, 0.0, 0.0, 0.0, 0.0, 0.0  // All zeros = upright
-    );
+    Config cfg;
+    std::array<double, NSTATE> x0{};  // all upright, at rest
+    CartNPendulum<NLINKS, double> plant(cfg.mc, cfg.masses, cfg.lengths, cfg.g, x0);
 
-    auto state = plant.getInitialLocalState();
-    std::vector<double> global_state(state.begin(), state.end());
+    std::vector<double> st(x0.begin(), x0.end());
+    std::span<const double> sp(st);
 
-    double KE = plant.compute(system::KineticEnergy{}, global_state);
-    double PE = plant.compute(system::PotentialEnergy{}, global_state);
-    double TE = plant.compute(system::TotalEnergy{}, global_state);
+    double KE = plant.kineticEnergy(sp);
+    double PE = plant.potentialEnergy(sp);
+    double TE = plant.totalEnergy(sp);
 
-    // At rest, KE should be zero
-    assert(approx_equal(KE, 0.0));
+    assert(approx_equal(KE, 0.0));  // at rest
 
-    // PE = m1*g*L1 + m2*g*(L1+L2) when upright (θ=0 means cos(θ)=1)
-    double expected_PE = 0.5 * 9.81 * 0.5 + 0.5 * 9.81 * (0.5 + 0.5);
-    assert(approx_equal(PE, expected_PE, 0.01));
-
-    // Total energy
+    // PE = Σ mᵢ g hᵢ with hᵢ = Σ_{j≤i} Lⱼ (all upright, cos=1).
+    double expected_PE = 0.0;
+    double height = 0.0;
+    for (size_t i = 0; i < NLINKS; ++i) {
+        height += cfg.lengths[i];
+        expected_PE += cfg.masses[i] * cfg.g * height;
+    }
+    assert(approx_equal(PE, expected_PE, 1e-9));
     assert(approx_equal(TE, KE + PE, EPSILON));
 
     test_passed("Energy computation");
 }
 
 // ============================================================================
-// Test: Uncontrolled fall (pendulum should fall)
+// Test: Uncontrolled dynamics (pendulums fall)
 // ============================================================================
 void test_uncontrolled_dynamics() {
     std::cout << "Test: Uncontrolled dynamics..." << std::endl;
 
-    // Create plant with small initial angle
-    CartDoublePendulum<double> plant(
-        1.0, 0.5, 0.5, 0.5, 0.5, 9.81,
-        0.0, 0.2, 0.1, 0.0, 0.0, 0.0  // Small tilt
-    );
+    Config cfg;
+    std::array<double, NSTATE> x0{};
+    for (size_t i = 1; i <= NLINKS; ++i) x0[i] = 0.1;  // tilted
 
-    auto system = makeTypedODESystem<double>(std::move(plant));
+    auto system = makeTypedODESystem<double>(
+        CartNPendulum<NLINKS, double>(cfg.mc, cfg.masses, cfg.lengths, cfg.g, x0)
+    );
     auto state = system.getInitialState();
 
-    // Simulate for 0.5 seconds with no control
-    double dt = 0.001;
-    double t = 0.0;
-    double t_end = 0.5;
-
+    double dt = 0.001, t = 0.0, t_end = 0.5;
     while (t < t_end) {
         auto derivs = system.computeDerivatives(t, state);
-        for (size_t i = 0; i < state.size(); ++i) {
-            state[i] = state[i] + derivs[i] * dt;
-        }
+        for (size_t i = 0; i < state.size(); ++i) state[i] += derivs[i] * dt;
         t += dt;
     }
 
-    // After 0.5 seconds, angles should have grown (unstable system)
-    double theta1 = state[1];
-    double theta2 = state[2];
-
-    // The pendulum should have started falling (angles increasing in magnitude)
-    assert(std::abs(theta1) > 0.2 || std::abs(theta2) > 0.1);
+    // With no control, the chain must have departed from its initial tilt.
+    double max_deviation = 0.0;
+    for (size_t i = 1; i <= NLINKS; ++i) {
+        max_deviation = std::max(max_deviation, std::abs(state[i] - 0.1));
+    }
+    assert(max_deviation > 0.05);
 
     test_passed("Uncontrolled dynamics");
 }
 
 // ============================================================================
-// Test: Linearization
+// Test: Linearization structure
 // ============================================================================
 void test_linearization() {
     std::cout << "Test: Linearization..." << std::endl;
 
-    double mc = 1.0, m1 = 0.5, m2 = 0.5, L1 = 0.5, L2 = 0.5, g = 9.81;
+    Config cfg;
+    auto [A, B] = linearizeCartNPendulum<NLINKS>(cfg.mc, cfg.masses, cfg.lengths, cfg.g);
 
-    auto [A, B] = linearizeCartDoublePendulum(mc, m1, m2, L1, L2, g);
+    constexpr size_t NDof = NLINKS + 1;
 
-    // Check structure: velocity rows
-    assert(approx_equal(A[0][3], 1.0));  // ẋ depends on xdot
-    assert(approx_equal(A[1][4], 1.0));  // θ̇₁ depends on ω₁
-    assert(approx_equal(A[2][5], 1.0));  // θ̇₂ depends on ω₂
+    // Upper-right block is identity: position rates equal velocities.
+    for (size_t i = 0; i < NDof; ++i) {
+        assert(approx_equal(A[i][NDof + i], 1.0));
+    }
 
-    // Acceleration rows should have non-zero entries for angles
-    // The system is unstable, so A should have positive eigenvalues
-    // For now, just check that A[4][1] and A[5][2] are positive (gravity destabilizes)
-    assert(A[4][1] > 0);  // α₁ increases when θ₁ > 0
-    assert(A[5][2] > 0);  // α₂ increases when θ₂ > 0
+    // Each angle's acceleration grows with its own angle (gravity destabilizes).
+    for (size_t a = 0; a < NLINKS; ++a) {
+        size_t accel_row = NDof + 1 + a;  // α_a row
+        size_t angle_col = 1 + a;         // θ_a column
+        assert(A[accel_row][angle_col] > 0.0);
+    }
 
-    // B matrix: only cart acceleration is directly affected by force
-    assert(B[3][0] > 0);  // Force affects cart acceleration
+    // Force enters the cart acceleration.
+    assert(B[NDof][0] > 0.0);
 
     test_passed("Linearization");
 }
 
 // ============================================================================
-// Test: LQR solver
+// Test: LQR solver produces finite gains
 // ============================================================================
 void test_lqr_solver() {
     std::cout << "Test: LQR solver..." << std::endl;
 
-    double mc = 1.0, m1 = 0.5, m2 = 0.5, L1 = 0.5, L2 = 0.5, g = 9.81;
+    Config cfg;
+    auto [A, B] = linearizeCartNPendulum<NLINKS>(cfg.mc, cfg.masses, cfg.lengths, cfg.g);
 
-    auto [A, B] = linearizeCartDoublePendulum(mc, m1, m2, L1, L2, g);
+    auto q_diag = lqrWeights();
+    std::array<std::array<double, NSTATE>, NSTATE> Q{};
+    for (size_t i = 0; i < NSTATE; ++i) Q[i][i] = q_diag[i];
 
-    // State weights: penalize angles more than position
-    std::array<std::array<double, 6>, 6> Q{};
-    Q[0][0] = 10.0;   // x position
-    Q[1][1] = 100.0;  // θ₁
-    Q[2][2] = 100.0;  // θ₂
-    Q[3][3] = 1.0;    // ẋ
-    Q[4][4] = 10.0;   // ω₁
-    Q[5][5] = 10.0;   // ω₂
-
-    // Control weight
     std::array<std::array<double, 1>, 1> R{};
-    R[0][0] = 0.1;
+    R[0][0] = 0.001;
 
-    LQR<6, 1> lqr;
-    bool converged = lqr.solve(A, B, Q, R);
-
+    LQR<NSTATE, 1> lqr;
+    bool converged = lqr.solve(A, B, Q, R, 0.005);
     std::cout << "    LQR converged: " << (converged ? "yes" : "no") << std::endl;
     assert(converged);
 
     auto K = lqr.getGain();
-
-    std::cout << "    K = [";
-    for (size_t i = 0; i < 6; ++i) {
-        std::cout << std::fixed << std::setprecision(2) << K[0][i];
-        if (i < 5) std::cout << ", ";
-    }
-    std::cout << "]" << std::endl;
-
-    // Gains should be non-zero and reasonable
-    for (size_t i = 0; i < 6; ++i) {
+    for (size_t i = 0; i < NSTATE; ++i) {
         assert(!std::isnan(K[0][i]));
         assert(!std::isinf(K[0][i]));
     }
@@ -211,133 +236,103 @@ void test_lqr_solver() {
 }
 
 // ============================================================================
-// Test: Closed-loop stabilization
+// Test: Closed-loop stabilization of 6 inverted pendulums
 // ============================================================================
 void test_closed_loop_stabilization() {
-    std::cout << "Test: Closed-loop stabilization..." << std::endl;
+    std::cout << "Test: Closed-loop stabilization (6 links)..." << std::endl;
 
-    // System parameters
-    double mc = 1.0, m1 = 0.5, m2 = 0.5, L1 = 0.5, L2 = 0.5, g = 9.81;
-
-    // Create controller with LQR gains
-    auto controller = InvertedDoublePendulumController::createWithLQR(
-        mc, m1, m2, L1, L2, g,
-        {10.0, 100.0, 100.0, 1.0, 10.0, 10.0},  // Q diagonal
-        0.1  // R
+    Config cfg;
+    auto controller = CartNPendulumController<NLINKS>::createWithLQR(
+        cfg.mc, cfg.masses, cfg.lengths, cfg.g, lqrWeights(), 0.001, 0.005
     );
+    controller.setSaturationLimits({-500.0}, {500.0});
 
-    // Set control saturation to realistic limits
-    controller.setSaturationLimits({-100.0}, {100.0});
+    CartNPendulum<NLINKS, double> plant(cfg.mc, cfg.masses, cfg.lengths, cfg.g);
+    TypedRegistry<double> reg{};
 
-    // Create plant with initial perturbation (near upright)
-    CartDoublePendulum<double> plant(
-        mc, m1, m2, L1, L2, g,
-        0.0,    // x
-        0.15,   // θ₁ = 0.15 rad ≈ 8.6°
-        0.1,    // θ₂ = 0.1 rad ≈ 5.7°
-        0.0,    // ẋ
-        0.0,    // ω₁
-        0.0     // ω₂
-    );
+    std::vector<double> state(NSTATE, 0.0);
+    for (size_t i = 1; i <= NLINKS; ++i) state[i] = 0.03;  // ~1.7° each
 
-    // Simulate closed-loop system
-    std::vector<double> state = {0.0, 0.15, 0.1, 0.0, 0.0, 0.0};
-    double dt = 0.001;
-    double t = 0.0;
-    double t_end = 5.0;  // 5 seconds
-
-    double max_theta1 = 0.0;
-    double max_theta2 = 0.0;
-    double max_force = 0.0;
+    double dt = 0.001, t = 0.0, t_end = 5.0;
+    double max_angle = 0.0, max_force = 0.0;
 
     while (t < t_end) {
-        // Compute control
-        std::array<double, 6> state_arr = {
-            state[0], state[1], state[2], state[3], state[4], state[5]
-        };
-        double F = controller.compute(state_arr)[0];
-
-        // Apply control to plant
-        plant.setControlForce(F);
-
-        // Compute derivatives
-        auto local_state = plant.getInitialLocalState();
-        for (size_t i = 0; i < 6; ++i) {
-            local_state[i] = state[i];
-        }
-
-        // Simple Euler integration with derivative computation
-        // (We're not using the full ODE system here for simplicity)
-        auto system = makeTypedODESystem<double>(
-            CartDoublePendulum<double>(mc, m1, m2, L1, L2, g)
-        );
-        auto& comp = system.template getComponent<0>();
-        comp.setControlForce(F);
-
-        auto derivs = system.computeDerivatives(t, state);
-
-        // Update state
-        for (size_t i = 0; i < 6; ++i) {
-            state[i] = state[i] + derivs[i] * dt;
-        }
-
-        // Track maximums
-        max_theta1 = std::max(max_theta1, std::abs(state[1]));
-        max_theta2 = std::max(max_theta2, std::abs(state[2]));
+        std::array<double, NSTATE> s_arr;
+        for (size_t i = 0; i < NSTATE; ++i) s_arr[i] = state[i];
+        double F = controller.computeForce(s_arr);
         max_force = std::max(max_force, std::abs(F));
 
+        plant.setControlForce(F);
+        std::span<const double> sp(state);
+        auto derivs = plant.derivatives(t, sp, sp, reg);
+        for (size_t i = 0; i < NSTATE; ++i) state[i] += derivs[i] * dt;
+
+        for (size_t i = 1; i <= NLINKS; ++i) {
+            max_angle = std::max(max_angle, std::abs(state[i]));
+        }
         t += dt;
     }
 
-    std::cout << "    Final state: x=" << std::fixed << std::setprecision(4) << state[0]
-              << ", θ₁=" << state[1] << ", θ₂=" << state[2] << std::endl;
-    std::cout << "    Max angles: θ₁=" << max_theta1 << ", θ₂=" << max_theta2 << std::endl;
-    std::cout << "    Max force: " << max_force << " N" << std::endl;
+    double final_angle = 0.0;
+    for (size_t i = 1; i <= NLINKS; ++i) {
+        final_angle = std::max(final_angle, std::abs(state[i]));
+    }
 
-    // Success criteria: angles should be small after 5 seconds
-    assert(std::abs(state[1]) < 0.05);  // θ₁ < 3°
-    assert(std::abs(state[2]) < 0.05);  // θ₂ < 3°
+    std::cout << "    Max angle during run: " << std::fixed << std::setprecision(4)
+              << max_angle << " rad" << std::endl;
+    std::cout << "    Final max angle:      " << final_angle << " rad" << std::endl;
+    std::cout << "    Max force:            " << max_force << " N" << std::endl;
+    std::cout << "    Final cart position:  " << state[0] << " m" << std::endl;
 
-    test_passed("Closed-loop stabilization");
+    // The controller must keep every link near upright and drive them back.
+    assert(max_angle < 0.2);     // never falls
+    assert(final_angle < 0.01);  // converges back toward upright
+
+    test_passed("Closed-loop stabilization (6 links)");
 }
 
 // ============================================================================
-// Test: State function tags work correctly
+// Test: State queries
 // ============================================================================
-void test_state_function_tags() {
-    std::cout << "Test: State function tags..." << std::endl;
+void test_state_queries() {
+    std::cout << "Test: State queries..." << std::endl;
 
-    CartDoublePendulum<double> plant(
-        1.0, 0.5, 0.5, 0.5, 0.5, 9.81,
-        1.0, 0.2, 0.1, 0.5, 0.3, -0.1
-    );
+    Config cfg;
+    std::array<double, NSTATE> x0{};
+    x0[0] = 1.0;                         // cart position
+    for (size_t i = 1; i <= NLINKS; ++i) x0[i] = 0.1 * static_cast<double>(i);
+    x0[NLINKS + 1] = 0.5;                // cart velocity
 
-    auto state = plant.getInitialLocalState();
-    std::vector<double> global(state.begin(), state.end());
+    CartNPendulum<NLINKS, double> plant(cfg.mc, cfg.masses, cfg.lengths, cfg.g, x0);
+    std::vector<double> st(x0.begin(), x0.end());
+    std::span<const double> sp(st);
 
-    // Test cart state functions
-    assert(approx_equal(plant.compute(cart::Position{}, global), 1.0));
-    assert(approx_equal(plant.compute(cart::Velocity{}, global), 0.5));
-    assert(approx_equal(plant.compute(cart::Mass{}, global), 1.0));
+    assert(approx_equal(plant.cartPosition(sp), 1.0));
+    assert(approx_equal(plant.cartVelocity(sp), 0.5));
+    assert(approx_equal(plant.compute(cart::Mass{}, st), cfg.mc));
 
-    // Test link 1 state functions
-    assert(approx_equal(plant.compute(link1::Angle{}, global), 0.2));
-    assert(approx_equal(plant.compute(link1::AngularVelocity{}, global), 0.3));
-    assert(approx_equal(plant.compute(link1::Length{}, global), 0.5));
+    for (size_t i = 0; i < NLINKS; ++i) {
+        assert(approx_equal(plant.linkAngle(i, sp), 0.1 * static_cast<double>(i + 1)));
+    }
 
-    // Test link 2 state functions
-    assert(approx_equal(plant.compute(link2::Angle{}, global), 0.1));
-    assert(approx_equal(plant.compute(link2::AngularVelocity{}, global), -0.1));
-    assert(approx_equal(plant.compute(link2::Length{}, global), 0.5));
+    // Tip of the first link: cart_x + L₁ sin θ₁, L₁ cos θ₁.
+    auto tip0 = plant.linkTipPosition(0, sp);
+    double theta1 = 0.1;
+    assert(approx_equal(tip0[0], 1.0 + cfg.lengths[0] * std::sin(theta1), 1e-9));
+    assert(approx_equal(tip0[1], cfg.lengths[0] * std::cos(theta1), 1e-9));
 
-    // Test tip positions
-    auto tip1 = plant.compute(link1::TipPosition{}, global);
-    double expected_x1 = 1.0 + 0.5 * std::sin(0.2);  // x + L1*sin(θ1)
-    double expected_y1 = 0.5 * std::cos(0.2);        // L1*cos(θ1)
-    assert(approx_equal(tip1[0], expected_x1, 0.001));
-    assert(approx_equal(tip1[1], expected_y1, 0.001));
+    // Tip of the last link must accumulate every link's contribution.
+    auto tipN = plant.linkTipPosition(NLINKS - 1, sp);
+    double px = 1.0, py = 0.0;
+    for (size_t i = 0; i < NLINKS; ++i) {
+        double th = 0.1 * static_cast<double>(i + 1);
+        px += cfg.lengths[i] * std::sin(th);
+        py += cfg.lengths[i] * std::cos(th);
+    }
+    assert(approx_equal(tipN[0], px, 1e-9));
+    assert(approx_equal(tipN[1], py, 1e-9));
 
-    test_passed("State function tags");
+    test_passed("State queries");
 }
 
 // ============================================================================
@@ -345,19 +340,20 @@ void test_state_function_tags() {
 // ============================================================================
 int main() {
     std::cout << "========================================" << std::endl;
-    std::cout << "Inverted Double Pendulum Control Tests" << std::endl;
+    std::cout << "Cart-N-Pendulum Control Tests (N = " << NLINKS << ")" << std::endl;
     std::cout << "========================================" << std::endl;
 
+    test_matches_double_pendulum();
     test_plant_creation();
     test_energy_computation();
     test_uncontrolled_dynamics();
     test_linearization();
     test_lqr_solver();
     test_closed_loop_stabilization();
-    test_state_function_tags();
+    test_state_queries();
 
     std::cout << "========================================" << std::endl;
-    std::cout << "All inverted pendulum tests passed!" << std::endl;
+    std::cout << "All cart-" << NLINKS << "-pendulum tests passed!" << std::endl;
     std::cout << "========================================" << std::endl;
 
     return 0;

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -128,7 +128,7 @@ if [ -f "sopot.js" ] && [ -f "sopot.wasm" ]; then
     echo "  // Rocket simulation:"
     echo "  const rocket = new Module.RocketSimulator();"
     echo ""
-    echo "  // Inverted double pendulum:"
+    echo "  // Inverted six-pendulum on a cart:"
     echo "  const pendulum = new Module.InvertedPendulumSimulator();"
     echo "  pendulum.setupDefault();"
     echo "  pendulum.step();"

--- a/wasm/wasm_inverted_pendulum.cpp
+++ b/wasm/wasm_inverted_pendulum.cpp
@@ -1,8 +1,9 @@
 /**
- * WebAssembly wrapper for SOPOT Inverted Double Pendulum Control System
+ * WebAssembly wrapper for the SOPOT Cart-N-Pendulum Control System.
  *
- * This file provides Emscripten embind bindings to expose the C++ inverted
- * double pendulum control system to JavaScript/TypeScript.
+ * Configured for a cart balancing a chain of NUM_LINKS inverted pendulums
+ * (six by default) stabilized by an LQR controller. Provides Emscripten
+ * embind bindings exposing the C++ control system to JavaScript/TypeScript.
  *
  * Build with:
  *   emcc -std=c++20 -lembind -O3 -s WASM=1 \
@@ -12,7 +13,7 @@
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
 #include <emscripten/emscripten.h>
-#include "../physics/control/cart_double_pendulum.hpp"
+#include "../physics/control/cart_n_pendulum.hpp"
 #include "../physics/control/lqr.hpp"
 #include "../physics/control/state_feedback_controller.hpp"
 #include "../core/typed_component.hpp"
@@ -28,246 +29,205 @@ using namespace sopot;
 using namespace sopot::control;
 
 /**
- * InvertedPendulumSimulator: JavaScript-friendly wrapper for the control system
+ * InvertedPendulumSimulator: JavaScript-friendly wrapper for the control system.
  *
- * This class provides:
- * - Clean initialization with physical parameters
- * - LQR controller with tunable weights
- * - Single-step integration for JavaScript-controlled animation
- * - State queries returning JavaScript objects
- * - Disturbance injection for demos
+ * The cart carries NUM_LINKS serially-connected pendulum links. The state
+ * vector has size 2*(NUM_LINKS+1) = [x, θ₁…θ_N, ẋ, ω₁…ω_N]. All physics and
+ * control runs in C++; the frontend handles visualization and interaction.
  */
 class InvertedPendulumSimulator {
+public:
+    static constexpr size_t NUM_LINKS = 6;
+    static constexpr size_t NSTATE = 2 * (NUM_LINKS + 1);  // 14
+
 private:
-    // System parameters
-    double m_cart_mass{1.0};
-    double m_mass1{0.5};
-    double m_mass2{0.5};
-    double m_length1{0.5};
-    double m_length2{0.5};
+    using Plant = CartNPendulum<NUM_LINKS, double>;
+    using Controller = CartNPendulumController<NUM_LINKS>;
+
+    // System parameters (uniform links by default).
+    double m_cart_mass{2.0};
+    std::array<double, NUM_LINKS> m_link_mass{};
+    std::array<double, NUM_LINKS> m_link_length{};
     double m_gravity{9.81};
 
-    // Controller
-    std::unique_ptr<InvertedDoublePendulumController> m_controller;
+    std::unique_ptr<Controller> m_controller;
 
-    // State: [x, θ₁, θ₂, ẋ, ω₁, ω₂]
-    std::array<double, 6> m_state{};
-    std::array<double, 6> m_initial_state{};
+    std::array<double, NSTATE> m_state{};
+    std::array<double, NSTATE> m_initial_state{};
 
-    // Simulation
     double m_time{0.0};
-    double m_dt{0.01};  // 10ms timestep
+    double m_dt{0.01};
     bool m_initialized{false};
     bool m_controller_enabled{true};
+    double m_max_force{500.0};
 
-    // Control limits
-    double m_max_force{100.0};  // N
+    // LQR design weights / parameters.
+    std::array<double, NSTATE> m_q_diag{};
+    double m_r{0.001};
+    double m_riccati_dt{0.005};
 
-    // History for visualization
     struct HistoryEntry {
         double time;
-        double x, theta1, theta2;
-        double xdot, omega1, omega2;
+        double x;
         double control_force;
+        double max_angle;
     };
     std::vector<HistoryEntry> m_history;
     bool m_record_history{true};
     static constexpr size_t MAX_HISTORY_SIZE = 10000;
 
-    // RK4 integration step
+    static constexpr size_t idxX()  { return 0; }
+    static constexpr size_t idxTheta(size_t i) { return 1 + i; }
+    static constexpr size_t idxXDot() { return NUM_LINKS + 1; }
+    static constexpr size_t idxOmega(size_t i) { return NUM_LINKS + 2 + i; }
+
+    double maxAbsAngle() const {
+        double m = 0.0;
+        for (size_t i = 0; i < NUM_LINKS; ++i) m = std::max(m, std::abs(m_state[idxTheta(i)]));
+        return m;
+    }
+
+    double currentControlForce() const {
+        if (!m_controller_enabled || !m_controller) return 0.0;
+        std::array<double, NSTATE> s = m_state;
+        double F = m_controller->computeForce(s);
+        return std::clamp(F, -m_max_force, m_max_force);
+    }
+
+    // Evaluate the plant derivative with a fixed control force.
+    std::array<double, NSTATE> derivativesAt(const std::array<double, NSTATE>& s, double F) const {
+        Plant plant(m_cart_mass, m_link_mass, m_link_length, m_gravity);
+        plant.setControlForce(F);
+        std::vector<double> sv(s.begin(), s.end());
+        std::span<const double> sp(sv);
+        TypedRegistry<double> reg{};
+        auto d = plant.derivatives(0.0, sp, sp, reg);
+        std::array<double, NSTATE> out{};
+        for (size_t i = 0; i < NSTATE; ++i) out[i] = d[i];
+        return out;
+    }
+
     void rk4Step(double dt) {
-        // Get control force
-        double F = 0.0;
-        if (m_controller_enabled && m_controller) {
-            F = m_controller->compute(m_state)[0];
-            F = std::clamp(F, -m_max_force, m_max_force);
-        }
+        // Control force held constant across the RK4 stages (computed once).
+        double F = currentControlForce();
 
-        // RK4 integration
-        auto derivs = [this, F](const std::array<double, 6>& s) -> std::array<double, 6> {
-            // Create temporary plant with current state
-            double x = s[0], theta1 = s[1], theta2 = s[2];
-            double xdot = s[3], omega1 = s[4], omega2 = s[5];
-
-            // Compute derivatives (physics from CartDoublePendulum)
-            double mc = m_cart_mass, m1 = m_mass1, m2 = m_mass2;
-            double L1 = m_length1, L2 = m_length2, g = m_gravity;
-
-            double s1 = std::sin(theta1), c1 = std::cos(theta1);
-            double s2 = std::sin(theta2), c2 = std::cos(theta2);
-            double s12 = std::sin(theta1 - theta2), c12 = std::cos(theta1 - theta2);
-
-            // Mass matrix elements
-            double M11 = mc + m1 + m2;
-            double M12 = (m1 + m2) * L1 * c1;
-            double M13 = m2 * L2 * c2;
-            double M22 = (m1 + m2) * L1 * L1;
-            double M23 = m2 * L1 * L2 * c12;
-            double M33 = m2 * L2 * L2;
-
-            // Right-hand side
-            double rhs1 = F + (m1 + m2) * L1 * s1 * omega1 * omega1
-                           + m2 * L2 * s2 * omega2 * omega2;
-            double rhs2 = (m1 + m2) * g * L1 * s1
-                        - m2 * L1 * L2 * s12 * omega2 * omega2;
-            double rhs3 = m2 * g * L2 * s2
-                        + m2 * L1 * L2 * s12 * omega1 * omega1;
-
-            // Solve 3x3 system using Cramer's rule
-            double det = M11 * (M22 * M33 - M23 * M23)
-                       - M12 * (M12 * M33 - M23 * M13)
-                       + M13 * (M12 * M23 - M22 * M13);
-
-            double C11 = M22 * M33 - M23 * M23;
-            double C12 = -(M12 * M33 - M13 * M23);
-            double C13 = M12 * M23 - M13 * M22;
-            double C21 = -(M12 * M33 - M13 * M23);
-            double C22 = M11 * M33 - M13 * M13;
-            double C23 = -(M11 * M23 - M12 * M13);
-            double C31 = M12 * M23 - M13 * M22;
-            double C32 = -(M11 * M23 - M12 * M13);
-            double C33 = M11 * M22 - M12 * M12;
-
-            if (std::abs(det) < 1e-12) {
-                throw std::runtime_error("InvertedPendulumSimulator: mass matrix is singular");
-            }
-            double inv_det = 1.0 / det;
-            double xddot = inv_det * (C11 * rhs1 + C12 * rhs2 + C13 * rhs3);
-            double alpha1 = inv_det * (C21 * rhs1 + C22 * rhs2 + C23 * rhs3);
-            double alpha2 = inv_det * (C31 * rhs1 + C32 * rhs2 + C33 * rhs3);
-
-            return {xdot, omega1, omega2, xddot, alpha1, alpha2};
+        auto add = [](const std::array<double, NSTATE>& a,
+                      const std::array<double, NSTATE>& b, double h) {
+            std::array<double, NSTATE> r{};
+            for (size_t i = 0; i < NSTATE; ++i) r[i] = a[i] + h * b[i];
+            return r;
         };
 
-        // RK4 stages
-        auto k1 = derivs(m_state);
+        auto k1 = derivativesAt(m_state, F);
+        auto k2 = derivativesAt(add(m_state, k1, 0.5 * dt), F);
+        auto k3 = derivativesAt(add(m_state, k2, 0.5 * dt), F);
+        auto k4 = derivativesAt(add(m_state, k3, dt), F);
 
-        std::array<double, 6> s2;
-        for (int i = 0; i < 6; i++) s2[i] = m_state[i] + 0.5 * dt * k1[i];
-        auto k2 = derivs(s2);
-
-        std::array<double, 6> s3;
-        for (int i = 0; i < 6; i++) s3[i] = m_state[i] + 0.5 * dt * k2[i];
-        auto k3 = derivs(s3);
-
-        std::array<double, 6> s4;
-        for (int i = 0; i < 6; i++) s4[i] = m_state[i] + dt * k3[i];
-        auto k4 = derivs(s4);
-
-        // Update state
-        for (int i = 0; i < 6; i++) {
-            m_state[i] += dt * (k1[i] + 2*k2[i] + 2*k3[i] + k4[i]) / 6.0;
+        for (size_t i = 0; i < NSTATE; ++i) {
+            m_state[i] += dt * (k1[i] + 2 * k2[i] + 2 * k3[i] + k4[i]) / 6.0;
         }
-
         m_time += dt;
 
-        // Record history
         if (m_record_history && m_history.size() < MAX_HISTORY_SIZE) {
-            m_history.push_back({
-                m_time,
-                m_state[0], m_state[1], m_state[2],
-                m_state[3], m_state[4], m_state[5],
-                F
-            });
+            m_history.push_back({m_time, m_state[idxX()], F, maxAbsAngle()});
         }
     }
 
+    void rebuildController() {
+        m_controller = std::make_unique<Controller>(
+            Controller::createWithLQR(
+                m_cart_mass, m_link_mass, m_link_length, m_gravity,
+                m_q_diag, m_r, m_riccati_dt
+            )
+        );
+        m_controller->setSaturationLimits({-m_max_force}, {m_max_force});
+    }
+
 public:
-    InvertedPendulumSimulator() = default;
+    InvertedPendulumSimulator() {
+        m_link_mass.fill(0.1);
+        m_link_length.fill(0.3);
+    }
 
     //=========================================================================
     // CONFIGURATION
     //=========================================================================
 
-    /**
-     * Set physical parameters
-     */
-    void setParameters(double cart_mass, double m1, double m2, double L1, double L2, double g) {
+    size_t getNumLinks() const { return NUM_LINKS; }
+
+    /** Set uniform physical parameters for every link. */
+    void setUniformParameters(double cart_mass, double link_mass, double link_length, double g) {
         m_cart_mass = cart_mass;
-        m_mass1 = m1;
-        m_mass2 = m2;
-        m_length1 = L1;
-        m_length2 = L2;
+        m_link_mass.fill(link_mass);
+        m_link_length.fill(link_length);
         m_gravity = g;
         m_initialized = false;
     }
 
-    /**
-     * Set initial state
-     * @param x Cart position (m)
-     * @param theta1 Angle of link 1 from vertical (rad)
-     * @param theta2 Angle of link 2 from vertical (rad)
-     * @param xdot Cart velocity (m/s)
-     * @param omega1 Angular velocity of link 1 (rad/s)
-     * @param omega2 Angular velocity of link 2 (rad/s)
-     */
-    void setInitialState(double x, double theta1, double theta2,
-                         double xdot, double omega1, double omega2) {
-        m_initial_state = {x, theta1, theta2, xdot, omega1, omega2};
+    /** Set per-link masses and lengths from JS arrays (length NUM_LINKS). */
+    void setParameters(double cart_mass, val masses_js, val lengths_js, double g) {
+        m_cart_mass = cart_mass;
+        for (size_t i = 0; i < NUM_LINKS; ++i) {
+            m_link_mass[i] = masses_js[i].as<double>();
+            m_link_length[i] = lengths_js[i].as<double>();
+        }
+        m_gravity = g;
+        m_initialized = false;
     }
 
-    /**
-     * Set simulation timestep
-     */
-    void setTimestep(double dt) {
-        m_dt = dt;
+    /** Set all link angles to the same value (cart at rest, upright chain). */
+    void setInitialAnglesUniform(double angle_rad) {
+        m_initial_state.fill(0.0);
+        for (size_t i = 0; i < NUM_LINKS; ++i) m_initial_state[idxTheta(i)] = angle_rad;
     }
 
-    /**
-     * Set maximum control force
-     */
+    /** Set the full initial state from a JS array (length NSTATE). */
+    void setInitialState(val state_js) {
+        for (size_t i = 0; i < NSTATE; ++i) m_initial_state[i] = state_js[i].as<double>();
+    }
+
+    /** Set initial angles from a JS array (length NUM_LINKS), cart at rest. */
+    void setInitialAngles(val angles_js) {
+        m_initial_state.fill(0.0);
+        for (size_t i = 0; i < NUM_LINKS; ++i) {
+            m_initial_state[idxTheta(i)] = angles_js[i].as<double>();
+        }
+    }
+
+    void setTimestep(double dt) { m_dt = dt; }
+
     void setMaxForce(double max_force) {
         m_max_force = max_force;
+        if (m_controller) m_controller->setSaturationLimits({-m_max_force}, {m_max_force});
     }
 
-    /**
-     * Configure LQR controller weights
-     * @param q_diag Diagonal elements of Q matrix [q_x, q_θ1, q_θ2, q_ẋ, q_ω1, q_ω2]
-     * @param r Control weight R
-     */
+    /** Configure the LQR controller (qDiag length NSTATE, scalar r). */
     void configureLQR(val q_diag_js, double r) {
-        std::array<double, 6> q_diag;
-        for (int i = 0; i < 6; i++) {
-            q_diag[i] = q_diag_js[i].as<double>();
-        }
-
-        m_controller = std::make_unique<InvertedDoublePendulumController>(
-            InvertedDoublePendulumController::createWithLQR(
-                m_cart_mass, m_mass1, m_mass2, m_length1, m_length2, m_gravity,
-                q_diag, r
-            )
-        );
-
-        // Set saturation limits
-        m_controller->setSaturationLimits({-m_max_force}, {m_max_force});
+        for (size_t i = 0; i < NSTATE; ++i) m_q_diag[i] = q_diag_js[i].as<double>();
+        m_r = r;
+        rebuildController();
     }
 
-    /**
-     * Initialize with default parameters
-     */
+    /** Initialize with sensible defaults for a six-link inverted pendulum. */
     void setupDefault() {
-        // Default parameters: lab-scale inverted pendulum
-        m_cart_mass = 1.0;
-        m_mass1 = 0.5;
-        m_mass2 = 0.5;
-        m_length1 = 0.5;
-        m_length2 = 0.5;
+        m_cart_mass = 2.0;
+        m_link_mass.fill(0.1);
+        m_link_length.fill(0.3);
         m_gravity = 9.81;
 
-        // Default initial state: small perturbation from upright
-        m_initial_state = {0.0, 0.1, 0.05, 0.0, 0.0, 0.0};
+        // Default LQR weights: heavy penalty on link angles.
+        m_q_diag.fill(0.0);
+        m_q_diag[idxX()] = 1.0;
+        for (size_t i = 0; i < NUM_LINKS; ++i) m_q_diag[idxTheta(i)] = 200.0;
+        m_q_diag[idxXDot()] = 1.0;
+        for (size_t i = 0; i < NUM_LINKS; ++i) m_q_diag[idxOmega(i)] = 10.0;
+        m_r = 0.001;
+        m_riccati_dt = 0.005;
 
-        // Default LQR weights
-        std::array<double, 6> q_diag = {10.0, 100.0, 100.0, 1.0, 10.0, 10.0};
-        double r = 0.1;
+        // Small initial perturbation from upright.
+        setInitialAnglesUniform(0.02);
 
-        m_controller = std::make_unique<InvertedDoublePendulumController>(
-            InvertedDoublePendulumController::createWithLQR(
-                m_cart_mass, m_mass1, m_mass2, m_length1, m_length2, m_gravity,
-                q_diag, r
-            )
-        );
-        m_controller->setSaturationLimits({-m_max_force}, {m_max_force});
+        rebuildController();
 
         m_state = m_initial_state;
         m_time = 0.0;
@@ -275,22 +235,12 @@ public:
         m_initialized = true;
     }
 
-    /**
-     * Reset to initial state
-     */
     void reset() {
         m_state = m_initial_state;
         m_time = 0.0;
         m_history.clear();
-
-        // Record initial state
         if (m_record_history) {
-            m_history.push_back({
-                0.0,
-                m_state[0], m_state[1], m_state[2],
-                m_state[3], m_state[4], m_state[5],
-                0.0
-            });
+            m_history.push_back({0.0, m_state[idxX()], 0.0, maxAbsAngle()});
         }
     }
 
@@ -298,67 +248,31 @@ public:
     // SIMULATION CONTROL
     //=========================================================================
 
-    /**
-     * Advance simulation by one timestep
-     * Returns true if simulation is stable (angles < 45°)
-     */
+    /** Advance one timestep; returns true while the chain is still upright. */
     bool step() {
-        if (!m_initialized) {
-            throw std::runtime_error("Call setupDefault() or configure before step()");
-        }
-
+        if (!m_initialized) throw std::runtime_error("Call setupDefault() or configure before step()");
         rk4Step(m_dt);
-
-        // Check if pendulum has fallen (angles > 45°)
-        double theta1 = std::abs(m_state[1]);
-        double theta2 = std::abs(m_state[2]);
-        return theta1 < M_PI/4 && theta2 < M_PI/4;
+        return maxAbsAngle() < M_PI / 4;
     }
 
-    /**
-     * Step with custom timestep
-     */
     bool stepWithDt(double dt) {
-        if (!m_initialized) {
-            throw std::runtime_error("Call setupDefault() or configure before step()");
-        }
-
+        if (!m_initialized) throw std::runtime_error("Call setupDefault() or configure before step()");
         rk4Step(dt);
-
-        double theta1 = std::abs(m_state[1]);
-        double theta2 = std::abs(m_state[2]);
-        return theta1 < M_PI/4 && theta2 < M_PI/4;
+        return maxAbsAngle() < M_PI / 4;
     }
 
-    /**
-     * Enable/disable controller (for demonstrating unstable behavior)
-     */
-    void setControllerEnabled(bool enabled) {
-        m_controller_enabled = enabled;
-    }
+    void setControllerEnabled(bool enabled) { m_controller_enabled = enabled; }
 
-    /**
-     * Apply impulse disturbance to cart
-     */
+    /** Apply a horizontal impulse to the cart. */
     void applyCartImpulse(double impulse) {
-        m_state[3] += impulse / m_cart_mass;  // Δv = J/m
+        m_state[idxXDot()] += impulse / m_cart_mass;
     }
 
-    /**
-     * Apply angular impulse to link 1
-     */
-    void applyLink1Impulse(double impulse) {
-        // Approximate: impulse affects angular velocity
-        double I1 = m_mass1 * m_length1 * m_length1;
-        m_state[4] += impulse / I1;
-    }
-
-    /**
-     * Apply angular impulse to link 2
-     */
-    void applyLink2Impulse(double impulse) {
-        double I2 = m_mass2 * m_length2 * m_length2;
-        m_state[5] += impulse / I2;
+    /** Apply an angular impulse to a given link (0-based index). */
+    void applyLinkImpulse(int link, double impulse) {
+        if (link < 0 || link >= static_cast<int>(NUM_LINKS)) return;
+        double I = m_link_mass[link] * m_link_length[link] * m_link_length[link];
+        m_state[idxOmega(static_cast<size_t>(link))] += impulse / I;
     }
 
     //=========================================================================
@@ -366,121 +280,74 @@ public:
     //=========================================================================
 
     double getTime() const { return m_time; }
+    double getCartPosition() const { return m_state[idxX()]; }
+    double getCartVelocity() const { return m_state[idxXDot()]; }
+    double getMaxAngle() const { return maxAbsAngle(); }
+    double getControlForce() const { return currentControlForce(); }
 
-    double getCartPosition() const { return m_state[0]; }
-    double getTheta1() const { return m_state[1]; }
-    double getTheta2() const { return m_state[2]; }
-    double getCartVelocity() const { return m_state[3]; }
-    double getOmega1() const { return m_state[4]; }
-    double getOmega2() const { return m_state[5]; }
-
-    /**
-     * Get link 1 tip position [x, y]
-     */
-    val getLink1TipPosition() const {
-        double x = m_state[0];
-        double theta1 = m_state[1];
-        double L1 = m_length1;
-
-        val result = val::object();
-        result.set("x", x + L1 * std::sin(theta1));
-        result.set("y", L1 * std::cos(theta1));
-        return result;
+    /** Angle of each link (radians) as a JS array. */
+    val getAngles() const {
+        std::vector<double> a(NUM_LINKS);
+        for (size_t i = 0; i < NUM_LINKS; ++i) a[i] = m_state[idxTheta(i)];
+        return val::array(a.begin(), a.end());
     }
 
-    /**
-     * Get link 2 tip position [x, y]
-     */
-    val getLink2TipPosition() const {
-        double x = m_state[0];
-        double theta1 = m_state[1];
-        double theta2 = m_state[2];
-        double L1 = m_length1, L2 = m_length2;
-
-        val result = val::object();
-        result.set("x", x + L1 * std::sin(theta1) + L2 * std::sin(theta2));
-        result.set("y", L1 * std::cos(theta1) + L2 * std::cos(theta2));
-        return result;
+    /** Angular velocity of each link as a JS array. */
+    val getAngularVelocities() const {
+        std::vector<double> w(NUM_LINKS);
+        for (size_t i = 0; i < NUM_LINKS; ++i) w[i] = m_state[idxOmega(i)];
+        return val::array(w.begin(), w.end());
     }
 
-    /**
-     * Get current control force
-     */
-    double getControlForce() const {
-        if (!m_controller_enabled || !m_controller) return 0.0;
-        double F = m_controller->compute(m_state)[0];
-        return std::clamp(F, -m_max_force, m_max_force);
+    /** Joint positions: [pivot, tip₁, …, tip_N] as a JS array of {x,y}. */
+    val getJoints() const {
+        val arr = val::array();
+        double px = m_state[idxX()];
+        double py = 0.0;
+        val pivot = val::object();
+        pivot.set("x", px);
+        pivot.set("y", py);
+        arr.set(0, pivot);
+        for (size_t i = 0; i < NUM_LINKS; ++i) {
+            double theta = m_state[idxTheta(i)];
+            px += m_link_length[i] * std::sin(theta);
+            py += m_link_length[i] * std::cos(theta);
+            val joint = val::object();
+            joint.set("x", px);
+            joint.set("y", py);
+            arr.set(static_cast<int>(i + 1), joint);
+        }
+        return arr;
     }
 
-    /**
-     * Get full state as JavaScript object
-     */
     val getFullState() const {
         val result = val::object();
         result.set("time", m_time);
-        result.set("x", m_state[0]);
-        result.set("theta1", m_state[1]);
-        result.set("theta2", m_state[2]);
-        result.set("xdot", m_state[3]);
-        result.set("omega1", m_state[4]);
-        result.set("omega2", m_state[5]);
+        result.set("x", m_state[idxX()]);
+        result.set("xdot", m_state[idxXDot()]);
         result.set("controlForce", getControlForce());
-        result.set("link1Tip", getLink1TipPosition());
-        result.set("link2Tip", getLink2TipPosition());
+        result.set("numLinks", static_cast<double>(NUM_LINKS));
+        result.set("angles", getAngles());
+        result.set("omegas", getAngularVelocities());
+        result.set("joints", getJoints());
+        // Backward-compatible scalar fields for the first two links.
+        result.set("theta1", m_state[idxTheta(0)]);
+        result.set("theta2", NUM_LINKS > 1 ? m_state[idxTheta(1)] : 0.0);
+        result.set("omega1", m_state[idxOmega(0)]);
+        result.set("omega2", NUM_LINKS > 1 ? m_state[idxOmega(1)] : 0.0);
         return result;
     }
 
-    /**
-     * Get visualization data: cart and pendulum geometry
-     */
     val getVisualizationData() const {
-        double x = m_state[0];
-        double theta1 = m_state[1];
-        double theta2 = m_state[2];
-        double L1 = m_length1, L2 = m_length2;
-
-        // Cart center
-        double cart_x = x;
-        double cart_y = 0.0;
-
-        // Link 1 joint (cart pivot)
-        double j1_x = cart_x;
-        double j1_y = cart_y;
-
-        // Link 1 tip = Link 2 joint
-        double j2_x = j1_x + L1 * std::sin(theta1);
-        double j2_y = j1_y + L1 * std::cos(theta1);
-
-        // Link 2 tip
-        double tip_x = j2_x + L2 * std::sin(theta2);
-        double tip_y = j2_y + L2 * std::cos(theta2);
-
         val result = val::object();
-
         val cart = val::object();
-        cart.set("x", cart_x);
-        cart.set("y", cart_y);
+        cart.set("x", m_state[idxX()]);
+        cart.set("y", 0.0);
         result.set("cart", cart);
-
-        val joint1 = val::object();
-        joint1.set("x", j1_x);
-        joint1.set("y", j1_y);
-        result.set("joint1", joint1);
-
-        val joint2 = val::object();
-        joint2.set("x", j2_x);
-        joint2.set("y", j2_y);
-        result.set("joint2", joint2);
-
-        val tip = val::object();
-        tip.set("x", tip_x);
-        tip.set("y", tip_y);
-        result.set("tip", tip);
-
-        result.set("theta1", theta1);
-        result.set("theta2", theta2);
+        result.set("joints", getJoints());
+        result.set("angles", getAngles());
         result.set("controlForce", getControlForce());
-
+        result.set("numLinks", static_cast<double>(NUM_LINKS));
         return result;
     }
 
@@ -492,33 +359,19 @@ public:
     size_t getHistorySize() const { return m_history.size(); }
     void clearHistory() { m_history.clear(); }
 
-    /**
-     * Get history as JavaScript arrays
-     */
     val getHistory() const {
         val result = val::object();
-
-        std::vector<double> time, x, theta1, theta2, xdot, omega1, omega2, control;
+        std::vector<double> time, x, control, maxangle;
         for (const auto& h : m_history) {
             time.push_back(h.time);
             x.push_back(h.x);
-            theta1.push_back(h.theta1);
-            theta2.push_back(h.theta2);
-            xdot.push_back(h.xdot);
-            omega1.push_back(h.omega1);
-            omega2.push_back(h.omega2);
             control.push_back(h.control_force);
+            maxangle.push_back(h.max_angle);
         }
-
         result.set("time", val::array(time.begin(), time.end()));
         result.set("x", val::array(x.begin(), x.end()));
-        result.set("theta1", val::array(theta1.begin(), theta1.end()));
-        result.set("theta2", val::array(theta2.begin(), theta2.end()));
-        result.set("xdot", val::array(xdot.begin(), xdot.end()));
-        result.set("omega1", val::array(omega1.begin(), omega1.end()));
-        result.set("omega2", val::array(omega2.begin(), omega2.end()));
         result.set("controlForce", val::array(control.begin(), control.end()));
-
+        result.set("maxAngle", val::array(maxangle.begin(), maxangle.end()));
         return result;
     }
 
@@ -527,22 +380,16 @@ public:
     //=========================================================================
 
     double getCartMass() const { return m_cart_mass; }
-    double getMass1() const { return m_mass1; }
-    double getMass2() const { return m_mass2; }
-    double getLength1() const { return m_length1; }
-    double getLength2() const { return m_length2; }
+    double getLinkMass(int i) const { return m_link_mass[static_cast<size_t>(i)]; }
+    double getLinkLength(int i) const { return m_link_length[static_cast<size_t>(i)]; }
     double getGravity() const { return m_gravity; }
     double getMaxForce() const { return m_max_force; }
     bool isInitialized() const { return m_initialized; }
     bool isControllerEnabled() const { return m_controller_enabled; }
 
-    /**
-     * Get LQR gain matrix as array
-     */
+    /** LQR gain row as a JS array (length NSTATE). */
     val getLQRGain() const {
-        if (!m_controller) {
-            return val::array();
-        }
+        if (!m_controller) return val::array();
         const auto& K = m_controller->getGain();
         std::vector<double> gains(K[0].begin(), K[0].end());
         return val::array(gains.begin(), gains.end());
@@ -558,8 +405,12 @@ EMSCRIPTEN_BINDINGS(inverted_pendulum) {
         .constructor<>()
 
         // Configuration
+        .function("getNumLinks", &InvertedPendulumSimulator::getNumLinks)
+        .function("setUniformParameters", &InvertedPendulumSimulator::setUniformParameters)
         .function("setParameters", &InvertedPendulumSimulator::setParameters)
+        .function("setInitialAnglesUniform", &InvertedPendulumSimulator::setInitialAnglesUniform)
         .function("setInitialState", &InvertedPendulumSimulator::setInitialState)
+        .function("setInitialAngles", &InvertedPendulumSimulator::setInitialAngles)
         .function("setTimestep", &InvertedPendulumSimulator::setTimestep)
         .function("setMaxForce", &InvertedPendulumSimulator::setMaxForce)
         .function("configureLQR", &InvertedPendulumSimulator::configureLQR)
@@ -571,20 +422,17 @@ EMSCRIPTEN_BINDINGS(inverted_pendulum) {
         .function("stepWithDt", &InvertedPendulumSimulator::stepWithDt)
         .function("setControllerEnabled", &InvertedPendulumSimulator::setControllerEnabled)
         .function("applyCartImpulse", &InvertedPendulumSimulator::applyCartImpulse)
-        .function("applyLink1Impulse", &InvertedPendulumSimulator::applyLink1Impulse)
-        .function("applyLink2Impulse", &InvertedPendulumSimulator::applyLink2Impulse)
+        .function("applyLinkImpulse", &InvertedPendulumSimulator::applyLinkImpulse)
 
         // State queries
         .function("getTime", &InvertedPendulumSimulator::getTime)
         .function("getCartPosition", &InvertedPendulumSimulator::getCartPosition)
-        .function("getTheta1", &InvertedPendulumSimulator::getTheta1)
-        .function("getTheta2", &InvertedPendulumSimulator::getTheta2)
         .function("getCartVelocity", &InvertedPendulumSimulator::getCartVelocity)
-        .function("getOmega1", &InvertedPendulumSimulator::getOmega1)
-        .function("getOmega2", &InvertedPendulumSimulator::getOmega2)
-        .function("getLink1TipPosition", &InvertedPendulumSimulator::getLink1TipPosition)
-        .function("getLink2TipPosition", &InvertedPendulumSimulator::getLink2TipPosition)
+        .function("getMaxAngle", &InvertedPendulumSimulator::getMaxAngle)
         .function("getControlForce", &InvertedPendulumSimulator::getControlForce)
+        .function("getAngles", &InvertedPendulumSimulator::getAngles)
+        .function("getAngularVelocities", &InvertedPendulumSimulator::getAngularVelocities)
+        .function("getJoints", &InvertedPendulumSimulator::getJoints)
         .function("getFullState", &InvertedPendulumSimulator::getFullState)
         .function("getVisualizationData", &InvertedPendulumSimulator::getVisualizationData)
 
@@ -596,10 +444,8 @@ EMSCRIPTEN_BINDINGS(inverted_pendulum) {
 
         // Parameters
         .function("getCartMass", &InvertedPendulumSimulator::getCartMass)
-        .function("getMass1", &InvertedPendulumSimulator::getMass1)
-        .function("getMass2", &InvertedPendulumSimulator::getMass2)
-        .function("getLength1", &InvertedPendulumSimulator::getLength1)
-        .function("getLength2", &InvertedPendulumSimulator::getLength2)
+        .function("getLinkMass", &InvertedPendulumSimulator::getLinkMass)
+        .function("getLinkLength", &InvertedPendulumSimulator::getLinkLength)
         .function("getGravity", &InvertedPendulumSimulator::getGravity)
         .function("getMaxForce", &InvertedPendulumSimulator::getMaxForce)
         .function("isInitialized", &InvertedPendulumSimulator::isInitialized)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -190,13 +190,14 @@ function App() {
           <InvertedPendulumVisualization
             state={pendulumSim.currentState}
             visualizationData={pendulumSim.visualizationData}
+            numLinks={pendulumSim.numLinks}
             showTelemetry={true}
             showForceArrow={true}
             onApplyImpulse={pendulumSim.applyDisturbance}
           />
         );
       }
-      return renderPlaceholder('⚖️ Inverted Double Pendulum', pendulumSim.isReady);
+      return renderPlaceholder('⚖️ Inverted 6-Pendulum on Cart', pendulumSim.isReady);
     }
   };
 
@@ -205,7 +206,7 @@ function App() {
     const description = simulationType === 'rocket'
       ? 'C++20 Physics Simulation compiled to WebAssembly'
       : simulationType === 'pendulum'
-        ? 'LQR-controlled inverted double pendulum with real-time stabilization'
+        ? 'LQR-controlled inverted six-pendulum chain with real-time stabilization'
         : 'High-performance physics simulation engine';
 
     const loadingText = 'Loading WebAssembly module...';
@@ -321,15 +322,8 @@ function App() {
                   controllerEnabled={pendulumSim.controllerEnabled}
                   playbackSpeed={pendulumSim.playbackSpeed}
                   lqrGains={pendulumSim.getLQRGains()}
-                  onInitialize={(t1, t2) => pendulumSim.initialize(
-                    /* cartMass */ undefined,
-                    /* m1 */ undefined,
-                    /* m2 */ undefined,
-                    /* L1 */ undefined,
-                    /* L2 */ undefined,
-                    t1,
-                    t2
-                  )}
+                  numLinks={pendulumSim.numLinks}
+                  onInitialize={pendulumSim.initialize}
                   onStart={pendulumSim.start}
                   onPause={pendulumSim.pause}
                   onReset={pendulumSim.reset}
@@ -387,12 +381,12 @@ function App() {
                       <span>{pendulumSim.currentState.x.toFixed(3)}m</span>
                     </div>
                     <div style={styles.infoRow}>
-                      <span>θ₁:</span>
-                      <span>{(pendulumSim.currentState.theta1 * 180 / Math.PI).toFixed(1)}°</span>
+                      <span>Links:</span>
+                      <span>{pendulumSim.currentState.numLinks}</span>
                     </div>
                     <div style={styles.infoRow}>
-                      <span>θ₂:</span>
-                      <span>{(pendulumSim.currentState.theta2 * 180 / Math.PI).toFixed(1)}°</span>
+                      <span>max |θ|:</span>
+                      <span>{(pendulumSim.currentState.angles.reduce((m, a) => Math.max(m, Math.abs(a)), 0) * 180 / Math.PI).toFixed(1)}°</span>
                     </div>
                     <div style={styles.infoRow}>
                       <span>Control Force:</span>
@@ -493,15 +487,8 @@ function App() {
                 controllerEnabled={pendulumSim.controllerEnabled}
                 playbackSpeed={pendulumSim.playbackSpeed}
                 lqrGains={pendulumSim.getLQRGains()}
-                onInitialize={(t1, t2) => pendulumSim.initialize(
-                  /* cartMass */ undefined,
-                  /* m1 */ undefined,
-                  /* m2 */ undefined,
-                  /* L1 */ undefined,
-                  /* L2 */ undefined,
-                  t1,
-                  t2
-                )}
+                numLinks={pendulumSim.numLinks}
+                onInitialize={pendulumSim.initialize}
                 onStart={pendulumSim.start}
                 onPause={pendulumSim.pause}
                 onReset={pendulumSim.reset}
@@ -551,20 +538,16 @@ function App() {
                       <span>{pendulumSim.currentState.xdot.toFixed(3)}m/s</span>
                     </div>
                     <div style={styles.infoRow}>
-                      <span>θ₁ (Link 1):</span>
-                      <span>{(pendulumSim.currentState.theta1 * 180 / Math.PI).toFixed(2)}°</span>
+                      <span>Links:</span>
+                      <span>{pendulumSim.currentState.numLinks}</span>
                     </div>
                     <div style={styles.infoRow}>
-                      <span>θ₂ (Link 2):</span>
-                      <span>{(pendulumSim.currentState.theta2 * 180 / Math.PI).toFixed(2)}°</span>
+                      <span>max |θ|:</span>
+                      <span>{(pendulumSim.currentState.angles.reduce((m, a) => Math.max(m, Math.abs(a)), 0) * 180 / Math.PI).toFixed(2)}°</span>
                     </div>
                     <div style={styles.infoRow}>
-                      <span>ω₁:</span>
-                      <span>{pendulumSim.currentState.omega1.toFixed(2)} rad/s</span>
-                    </div>
-                    <div style={styles.infoRow}>
-                      <span>ω₂:</span>
-                      <span>{pendulumSim.currentState.omega2.toFixed(2)} rad/s</span>
+                      <span>max |ω|:</span>
+                      <span>{pendulumSim.currentState.omegas.reduce((m, w) => Math.max(m, Math.abs(w)), 0).toFixed(2)} rad/s</span>
                     </div>
                     <div style={styles.infoRow}>
                       <span>Control Force:</span>

--- a/web/src/components/InvertedPendulumControlPanel.tsx
+++ b/web/src/components/InvertedPendulumControlPanel.tsx
@@ -9,13 +9,14 @@ interface InvertedPendulumControlPanelProps {
   controllerEnabled: boolean;
   playbackSpeed: number;
   lqrGains: number[] | null;
-  onInitialize: (theta1?: number, theta2?: number) => void;
+  numLinks: number;
+  onInitialize: (initialAngleRad?: number) => void;
   onStart: () => void;
   onPause: () => void;
   onReset: () => void;
   onSetPlaybackSpeed: (speed: number) => void;
   onSetControllerEnabled: (enabled: boolean) => void;
-  onApplyDisturbance: (type: 'cart' | 'link1' | 'link2', impulse: number) => void;
+  onApplyDisturbance: (type: 'cart' | 'link', index: number, impulse: number) => void;
 }
 
 export function InvertedPendulumControlPanel({
@@ -26,6 +27,7 @@ export function InvertedPendulumControlPanel({
   controllerEnabled,
   playbackSpeed,
   lqrGains,
+  numLinks,
   onInitialize,
   onStart,
   onPause,
@@ -34,19 +36,14 @@ export function InvertedPendulumControlPanel({
   onSetControllerEnabled,
   onApplyDisturbance,
 }: InvertedPendulumControlPanelProps) {
-  const [initialTheta1, setInitialTheta1] = useState(5.7); // degrees
-  const [initialTheta2, setInitialTheta2] = useState(2.9); // degrees
+  const [initialTilt, setInitialTilt] = useState(1.7); // degrees, applied to every link
   const [disturbanceStrength, setDisturbanceStrength] = useState(5);
 
   const handleInitialize = () => {
-    const theta1Rad = (initialTheta1 * Math.PI) / 180;
-    const theta2Rad = (initialTheta2 * Math.PI) / 180;
-    onInitialize(theta1Rad, theta2Rad);
+    onInitialize((initialTilt * Math.PI) / 180);
   };
 
-  const formatAngle = (rad: number) => {
-    return ((rad * 180) / Math.PI).toFixed(1);
-  };
+  const formatAngle = (rad: number) => ((rad * 180) / Math.PI).toFixed(1);
 
   return (
     <div className="control-panel" style={{
@@ -56,49 +53,33 @@ export function InvertedPendulumControlPanel({
       maxWidth: '400px',
     }}>
       <h3 style={{ marginTop: 0, marginBottom: '16px', color: 'var(--text-primary)' }}>
-        Inverted Pendulum Control
+        Inverted {numLinks}-Pendulum Control
       </h3>
 
       {/* Initialization Section */}
       {!isInitialized && (
         <div style={{ marginBottom: '16px' }}>
-          <h4 style={{ margin: '0 0 8px 0', color: 'var(--text-secondary)' }}>Initial Angles</h4>
-          <div style={{ display: 'flex', gap: '16px', marginBottom: '8px' }}>
-            <label style={{ flex: 1 }}>
-              <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>θ₁ (degrees)</span>
-              <input
-                type="number"
-                value={initialTheta1}
-                onChange={(e) => setInitialTheta1(parseFloat(e.target.value) || 0)}
-                style={{
-                  width: '100%',
-                  padding: '8px',
-                  marginTop: '4px',
-                  backgroundColor: 'var(--bg-tertiary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '4px',
-                  color: 'var(--text-primary)',
-                }}
-              />
-            </label>
-            <label style={{ flex: 1 }}>
-              <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>θ₂ (degrees)</span>
-              <input
-                type="number"
-                value={initialTheta2}
-                onChange={(e) => setInitialTheta2(parseFloat(e.target.value) || 0)}
-                style={{
-                  width: '100%',
-                  padding: '8px',
-                  marginTop: '4px',
-                  backgroundColor: 'var(--bg-tertiary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '4px',
-                  color: 'var(--text-primary)',
-                }}
-              />
-            </label>
-          </div>
+          <h4 style={{ margin: '0 0 8px 0', color: 'var(--text-secondary)' }}>Initial Tilt</h4>
+          <label style={{ display: 'block', marginBottom: '8px' }}>
+            <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>
+              Angle per link (degrees)
+            </span>
+            <input
+              type="number"
+              value={initialTilt}
+              step="0.1"
+              onChange={(e) => setInitialTilt(parseFloat(e.target.value) || 0)}
+              style={{
+                width: '100%',
+                padding: '8px',
+                marginTop: '4px',
+                backgroundColor: 'var(--bg-tertiary)',
+                border: '1px solid var(--border-color)',
+                borderRadius: '4px',
+                color: 'var(--text-primary)',
+              }}
+            />
+          </label>
           <button
             onClick={handleInitialize}
             className="touch-button btn-primary"
@@ -171,7 +152,7 @@ export function InvertedPendulumControlPanel({
             </label>
             {!controllerEnabled && (
               <p style={{ margin: '4px 0 0 26px', fontSize: '12px', color: 'var(--accent-danger)' }}>
-                Warning: Pendulum will fall without controller!
+                Warning: the pendulums will fall without the controller!
               </p>
             )}
           </div>
@@ -193,53 +174,29 @@ export function InvertedPendulumControlPanel({
                 style={{ width: '100%', marginTop: '4px' }}
               />
             </label>
-            <div style={{ display: 'flex', gap: '8px' }}>
+            <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
               <button
-                onClick={() => onApplyDisturbance('cart', disturbanceStrength)}
-                style={{
-                  flex: 1,
-                  padding: '8px',
-                  backgroundColor: 'var(--bg-tertiary)',
-                  color: 'var(--text-primary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                  fontSize: '12px',
-                }}
+                onClick={() => onApplyDisturbance('cart', 0, disturbanceStrength)}
+                style={disturbanceButtonStyle}
               >
                 Push Cart →
               </button>
               <button
-                onClick={() => onApplyDisturbance('link1', disturbanceStrength * 0.1)}
-                style={{
-                  flex: 1,
-                  padding: '8px',
-                  backgroundColor: 'var(--bg-tertiary)',
-                  color: 'var(--text-primary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                  fontSize: '12px',
-                }}
+                onClick={() => onApplyDisturbance('link', 0, disturbanceStrength * 0.1)}
+                style={disturbanceButtonStyle}
               >
-                Tap Link 1
+                Tap Bottom Link
               </button>
               <button
-                onClick={() => onApplyDisturbance('link2', disturbanceStrength * 0.05)}
-                style={{
-                  flex: 1,
-                  padding: '8px',
-                  backgroundColor: 'var(--bg-tertiary)',
-                  color: 'var(--text-primary)',
-                  border: '1px solid var(--border-color)',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                  fontSize: '12px',
-                }}
+                onClick={() => onApplyDisturbance('link', numLinks - 1, disturbanceStrength * 0.05)}
+                style={disturbanceButtonStyle}
               >
-                Tap Link 2
+                Tap Top Link
               </button>
             </div>
+            <p style={{ margin: '6px 0 0 0', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+              Tip: click any mass in the visualization to nudge that link.
+            </p>
           </div>
 
           {/* Status */}
@@ -252,10 +209,10 @@ export function InvertedPendulumControlPanel({
               marginBottom: '16px',
             }}>
               <p style={{ margin: 0, color: 'var(--accent-danger)', fontWeight: 'bold' }}>
-                Pendulum Fell!
+                A Pendulum Fell!
               </p>
               <p style={{ margin: '4px 0 0 0', fontSize: '12px', color: 'var(--text-secondary)' }}>
-                The pendulum angles exceeded 45°. Click Reset to try again.
+                A link exceeded 45°. Click Reset to try again.
               </p>
             </div>
           )}
@@ -277,17 +234,21 @@ export function InvertedPendulumControlPanel({
                 <span style={{ color: 'var(--text-tertiary)' }}>Cart x:</span>
                 <span style={{ color: 'var(--text-primary)' }}>{state.x.toFixed(3)} m</span>
 
-                <span style={{ color: 'var(--text-tertiary)' }}>θ₁:</span>
-                <span style={{ color: 'var(--text-primary)' }}>{formatAngle(state.theta1)}°</span>
-
-                <span style={{ color: 'var(--text-tertiary)' }}>θ₂:</span>
-                <span style={{ color: 'var(--text-primary)' }}>{formatAngle(state.theta2)}°</span>
+                <span style={{ color: 'var(--text-tertiary)' }}>max |θ|:</span>
+                <span style={{ color: 'var(--text-primary)' }}>
+                  {formatAngle(state.angles.reduce((m, a) => Math.max(m, Math.abs(a)), 0))}°
+                </span>
 
                 <span style={{ color: 'var(--text-tertiary)' }}>Control:</span>
                 <span style={{ color: state.controlForce > 0 ? '#4ade80' : '#f87171' }}>
                   {state.controlForce.toFixed(1)} N
                 </span>
               </div>
+              {state.angles.length > 0 && (
+                <div style={{ marginTop: '8px', color: 'var(--text-tertiary)' }}>
+                  θ = [{state.angles.map((a) => formatAngle(a)).join(', ')}]°
+                </div>
+              )}
             </div>
           )}
 
@@ -300,9 +261,11 @@ export function InvertedPendulumControlPanel({
               borderRadius: '6px',
               fontSize: '11px',
             }}>
-              <h4 style={{ margin: '0 0 4px 0', color: 'var(--text-secondary)' }}>LQR Gains</h4>
-              <div style={{ fontFamily: 'monospace', color: 'var(--text-tertiary)' }}>
-                K = [{lqrGains.map(k => k.toFixed(1)).join(', ')}]
+              <h4 style={{ margin: '0 0 4px 0', color: 'var(--text-secondary)' }}>
+                LQR Gains ({lqrGains.length} states)
+              </h4>
+              <div style={{ fontFamily: 'monospace', color: 'var(--text-tertiary)', wordBreak: 'break-all' }}>
+                K = [{lqrGains.map((k) => k.toFixed(1)).join(', ')}]
               </div>
             </div>
           )}
@@ -311,5 +274,17 @@ export function InvertedPendulumControlPanel({
     </div>
   );
 }
+
+const disturbanceButtonStyle: React.CSSProperties = {
+  flex: 1,
+  minWidth: '90px',
+  padding: '8px',
+  backgroundColor: 'var(--bg-tertiary)',
+  color: 'var(--text-primary)',
+  border: '1px solid var(--border-color)',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  fontSize: '12px',
+};
 
 export default InvertedPendulumControlPanel;

--- a/web/src/components/InvertedPendulumVisualization.tsx
+++ b/web/src/components/InvertedPendulumVisualization.tsx
@@ -6,48 +6,47 @@ const TOUCH_FEEDBACK_DURATION_MS = 200; // milliseconds - visual feedback durati
 const HIT_AREA_EXPANSION_PX = 10; // pixels - expansion of hit detection areas
 const IMPULSE_CART_NS = 5; // N·s - impulse strength for cart
 const IMPULSE_LINK_NS = 0.5; // N·s - impulse strength for links
-const MASS_BASE_RADIUS_PX = 8; // pixels - base radius for mass rendering
-const MASS_RADIUS_SCALE_FACTOR = 10; // pixels per kg - scaling factor for mass size
+const MASS_BASE_RADIUS_PX = 6; // pixels - base radius for mass rendering
+const MASS_RADIUS_SCALE_FACTOR = 12; // pixels per kg - scaling factor for mass size
 const CART_WIDTH_M = 0.3; // meters - cart width in simulation units
 const CART_HEIGHT_M = 0.15; // meters - cart height in simulation units
-const GROUND_Y_FACTOR = 0.7; // fraction - ground position relative to canvas height
-const SCALE_FACTOR = 0.8; // scaling factor for coordinate transforms
-const VIEW_HEIGHT_FACTOR = 1.5; // factor for view height calculation
+const GROUND_Y_FACTOR = 0.75; // fraction - ground position relative to canvas height
+const SCALE_FACTOR = 0.85; // scaling factor for coordinate transforms
+const VIEW_HEIGHT_FACTOR = 1.3; // factor for view height calculation
 const HIGHLIGHT_GLOW_RADIUS_PX = 20; // pixels - glow radius when element is touched
+
+// Distinct hues for the link chain (cycled if there are more links than colors).
+const LINK_COLORS = ['#6366f1', '#8b5cf6', '#a855f7', '#d946ef', '#ec4899', '#f43f5e'];
 
 export interface PendulumState {
   time: number;
-  x: number;       // Cart position
-  theta1: number;  // Link 1 angle from vertical
-  theta2: number;  // Link 2 angle from vertical
-  xdot: number;    // Cart velocity
-  omega1: number;  // Link 1 angular velocity
-  omega2: number;  // Link 2 angular velocity
+  x: number;            // Cart position
+  xdot: number;         // Cart velocity
+  angles: number[];     // Link angles from vertical
+  omegas: number[];     // Link angular velocities
   controlForce: number;
+  numLinks: number;
 }
 
 export interface PendulumVisualizationData {
   cart: { x: number; y: number };
-  joint1: { x: number; y: number };
-  joint2: { x: number; y: number };
-  tip: { x: number; y: number };
-  theta1: number;
-  theta2: number;
+  joints: Array<{ x: number; y: number }>; // [pivot, tip₁, …, tip_N]
+  angles: number[];
   controlForce: number;
+  numLinks: number;
 }
 
 interface InvertedPendulumVisualizationProps {
   state: PendulumState | null;
   visualizationData?: PendulumVisualizationData | null;
   cartMass?: number;
-  mass1?: number;
-  mass2?: number;
-  length1?: number;
-  length2?: number;
+  linkMass?: number;
+  linkLength?: number;
+  numLinks?: number;
   showTelemetry?: boolean;
   showForceArrow?: boolean;
   trackWidth?: number;  // Total track width for cart travel
-  onApplyImpulse?: (type: 'cart' | 'link1' | 'link2', impulse: number) => void;
+  onApplyImpulse?: (type: 'cart' | 'link', index: number, impulse: number) => void;
 }
 
 /**
@@ -62,11 +61,10 @@ function getCSSVariable(variableName: string): string {
 export function InvertedPendulumVisualization({
   state,
   visualizationData,
-  cartMass: _cartMass = 1.0,
-  mass1 = 0.5,
-  mass2 = 0.5,
-  length1 = 0.7,
-  length2 = 0.7,
+  cartMass: _cartMass = 2.0,
+  linkMass = 0.1,
+  linkLength = 0.3,
+  numLinks = 6,
   showTelemetry = true,
   showForceArrow = true,
   trackWidth = 3.0,
@@ -75,7 +73,32 @@ export function InvertedPendulumVisualization({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
-  const [highlightedElement, setHighlightedElement] = useState<'cart' | 'link1' | 'link2' | null>(null);
+  // Highlighted element: 'cart' or a link index.
+  const [highlighted, setHighlighted] = useState<{ type: 'cart' | 'link'; index: number } | null>(null);
+
+  // Resolve the chain of joint positions (pivot + tips) from data or state.
+  const resolveJoints = useCallback((): Array<{ x: number; y: number }> => {
+    if (visualizationData?.joints && visualizationData.joints.length > 0) {
+      return visualizationData.joints;
+    }
+    if (state?.angles && state.angles.length > 0) {
+      const joints: Array<{ x: number; y: number }> = [{ x: state.x, y: 0 }];
+      let px = state.x;
+      let py = 0;
+      for (let i = 0; i < state.angles.length; i++) {
+        px += linkLength * Math.sin(state.angles[i]);
+        py += linkLength * Math.cos(state.angles[i]);
+        joints.push({ x: px, y: py });
+      }
+      return joints;
+    }
+    // Default: upright chain at origin.
+    const joints: Array<{ x: number; y: number }> = [{ x: 0, y: 0 }];
+    for (let i = 0; i < numLinks; i++) {
+      joints.push({ x: 0, y: (i + 1) * linkLength });
+    }
+    return joints;
+  }, [visualizationData, state, linkLength, numLinks]);
 
   // Handle canvas resizing
   useEffect(() => {
@@ -91,41 +114,9 @@ export function InvertedPendulumVisualization({
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
-  // Handle touch/click interaction
-  const handleInteraction = useCallback((clientX: number, clientY: number) => {
-    if (!canvasRef.current || !state || !onApplyImpulse) return;
-
-    const canvas = canvasRef.current;
-    const rect = canvas.getBoundingClientRect();
-    const canvasX = clientX - rect.left;
-    const canvasY = clientY - rect.top;
-
-    // Get current visualization positions
-    let cart: { x: number; y: number };
-    let joint2: { x: number; y: number };
-    let tip: { x: number; y: number };
-
-    if (visualizationData) {
-      cart = visualizationData.cart;
-      joint2 = visualizationData.joint2;
-      tip = visualizationData.tip;
-    } else {
-      const x = state.x;
-      const theta1 = state.theta1;
-      const theta2 = state.theta2;
-      cart = { x, y: 0 };
-      joint2 = {
-        x: x + length1 * Math.sin(theta1),
-        y: length1 * Math.cos(theta1)
-      };
-      tip = {
-        x: joint2.x + length2 * Math.sin(theta2),
-        y: joint2.y + length2 * Math.cos(theta2)
-      };
-    }
-
-    // Transform to canvas coordinates (same as rendering)
-    const totalHeight = length1 + length2;
+  // Compute the simulation->canvas transform (shared by render and hit testing).
+  const computeTransform = useCallback(() => {
+    const totalHeight = numLinks * linkLength;
     const padding = CANVAS_PADDING_PX;
     const viewWidth = Math.max(trackWidth, 2 * totalHeight);
     const viewHeight = totalHeight * VIEW_HEIGHT_FACTOR;
@@ -137,61 +128,63 @@ export function InvertedPendulumVisualization({
     const centerX = dimensions.width / 2;
     const groundY = dimensions.height * GROUND_Y_FACTOR;
 
-    const toCanvasX = (x: number) => centerX + x * scale;
-    const toCanvasY = (y: number) => groundY - y * scale;
+    return {
+      scale,
+      toCanvasX: (x: number) => centerX + x * scale,
+      toCanvasY: (y: number) => groundY - y * scale,
+      groundY,
+      centerX,
+    };
+  }, [dimensions, numLinks, linkLength, trackWidth]);
 
+  // Handle touch/click interaction
+  const handleInteraction = useCallback((clientX: number, clientY: number) => {
+    if (!canvasRef.current || !onApplyImpulse) return;
+
+    const canvas = canvasRef.current;
+    const rect = canvas.getBoundingClientRect();
+    const canvasX = clientX - rect.left;
+    const canvasY = clientY - rect.top;
+
+    const joints = resolveJoints();
+    if (joints.length === 0) return;
+
+    const { scale, toCanvasX, toCanvasY, groundY } = computeTransform();
     const cartWidth = CART_WIDTH_M * scale;
     const cartHeight = CART_HEIGHT_M * scale;
-    const cartX = toCanvasX(cart.x);
-    const cartY = groundY;
-    const j2x = toCanvasX(joint2.x);
-    const j2y = toCanvasY(joint2.y);
-    const tipX = toCanvasX(tip.x);
-    const tipY = toCanvasY(tip.y);
+    const massRadius = MASS_BASE_RADIUS_PX + linkMass * MASS_RADIUS_SCALE_FACTOR;
 
-    const mass1Radius = MASS_BASE_RADIUS_PX + mass1 * MASS_RADIUS_SCALE_FACTOR;
-    const mass2Radius = MASS_BASE_RADIUS_PX + mass2 * MASS_RADIUS_SCALE_FACTOR;
-
-    // Check what was clicked
-    let clickedElement: 'cart' | 'link1' | 'link2' | null = null;
-
-    // Check mass 2 (tip)
-    const distTip = Math.sqrt(Math.pow(canvasX - tipX, 2) + Math.pow(canvasY - tipY, 2));
-    if (distTip < mass2Radius + HIT_AREA_EXPANSION_PX) {
-      clickedElement = 'link2';
-    }
-
-    // Check mass 1 (joint2)
-    if (!clickedElement) {
-      const distJoint2 = Math.sqrt(Math.pow(canvasX - j2x, 2) + Math.pow(canvasY - j2y, 2));
-      if (distJoint2 < mass1Radius + HIT_AREA_EXPANSION_PX) {
-        clickedElement = 'link1';
+    // Check link masses (tips), nearest first.
+    for (let i = joints.length - 1; i >= 1; i--) {
+      const jx = toCanvasX(joints[i].x);
+      const jy = toCanvasY(joints[i].y);
+      const dist = Math.hypot(canvasX - jx, canvasY - jy);
+      if (dist < massRadius + HIT_AREA_EXPANSION_PX) {
+        onApplyImpulse('link', i - 1, IMPULSE_LINK_NS);
+        setHighlighted({ type: 'link', index: i - 1 });
+        setTimeout(() => setHighlighted(null), TOUCH_FEEDBACK_DURATION_MS);
+        return;
       }
     }
 
-    // Check cart
-    if (!clickedElement) {
-      if (canvasX >= cartX - cartWidth / 2 - HIT_AREA_EXPANSION_PX && canvasX <= cartX + cartWidth / 2 + HIT_AREA_EXPANSION_PX &&
-          canvasY >= cartY - cartHeight - HIT_AREA_EXPANSION_PX && canvasY <= cartY + HIT_AREA_EXPANSION_PX) {
-        clickedElement = 'cart';
-      }
+    // Check cart.
+    const cartX = toCanvasX(joints[0].x);
+    if (
+      canvasX >= cartX - cartWidth / 2 - HIT_AREA_EXPANSION_PX &&
+      canvasX <= cartX + cartWidth / 2 + HIT_AREA_EXPANSION_PX &&
+      canvasY >= groundY - cartHeight - HIT_AREA_EXPANSION_PX &&
+      canvasY <= groundY + HIT_AREA_EXPANSION_PX
+    ) {
+      onApplyImpulse('cart', 0, IMPULSE_CART_NS);
+      setHighlighted({ type: 'cart', index: 0 });
+      setTimeout(() => setHighlighted(null), TOUCH_FEEDBACK_DURATION_MS);
     }
-
-    if (clickedElement) {
-      // Apply impulse based on clicked element
-      const impulseStrength = clickedElement === 'cart' ? IMPULSE_CART_NS : IMPULSE_LINK_NS;
-      onApplyImpulse(clickedElement, impulseStrength);
-
-      // Visual feedback
-      setHighlightedElement(clickedElement);
-      setTimeout(() => setHighlightedElement(null), TOUCH_FEEDBACK_DURATION_MS);
-    }
-  }, [state, visualizationData, dimensions, length1, length2, mass1, mass2, trackWidth, onApplyImpulse]);
+  }, [resolveJoints, computeTransform, linkMass, onApplyImpulse]);
 
   // Touch event handlers
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas || !state) return;
+    if (!canvas) return;
 
     const handleTouch = (e: TouchEvent) => {
       e.preventDefault();
@@ -212,7 +205,7 @@ export function InvertedPendulumVisualization({
       canvas.removeEventListener('touchstart', handleTouch);
       canvas.removeEventListener('click', handleClick);
     };
-  }, [handleInteraction, state]);
+  }, [handleInteraction]);
 
   // Render the pendulum
   useEffect(() => {
@@ -226,67 +219,10 @@ export function InvertedPendulumVisualization({
     ctx.fillStyle = getCSSVariable('--bg-primary') || '#1a1a2e';
     ctx.fillRect(0, 0, dimensions.width, dimensions.height);
 
-    // Get visualization data or compute from state
-    let cart: { x: number; y: number };
-    let joint1: { x: number; y: number };
-    let joint2: { x: number; y: number };
-    let tip: { x: number; y: number };
-    let theta1: number;
-    let theta2: number;
-    let controlForce: number;
+    const joints = resolveJoints();
+    const controlForce = visualizationData?.controlForce ?? state?.controlForce ?? 0;
 
-    if (visualizationData) {
-      cart = visualizationData.cart;
-      joint1 = visualizationData.joint1;
-      joint2 = visualizationData.joint2;
-      tip = visualizationData.tip;
-      theta1 = visualizationData.theta1;
-      theta2 = visualizationData.theta2;
-      controlForce = visualizationData.controlForce;
-    } else if (state) {
-      const x = state.x;
-      theta1 = state.theta1;
-      theta2 = state.theta2;
-      controlForce = state.controlForce;
-
-      cart = { x, y: 0 };
-      joint1 = { x, y: 0 };
-      joint2 = {
-        x: x + length1 * Math.sin(theta1),
-        y: length1 * Math.cos(theta1)
-      };
-      tip = {
-        x: joint2.x + length2 * Math.sin(theta2),
-        y: joint2.y + length2 * Math.cos(theta2)
-      };
-    } else {
-      // Default state: upright at origin
-      cart = { x: 0, y: 0 };
-      joint1 = { x: 0, y: 0 };
-      joint2 = { x: 0, y: length1 };
-      tip = { x: 0, y: length1 + length2 };
-      theta1 = 0;
-      theta2 = 0;
-      controlForce = 0;
-    }
-
-    // Scale and center the visualization
-    const totalHeight = length1 + length2;
-    const padding = CANVAS_PADDING_PX;
-    const viewWidth = Math.max(trackWidth, 2 * totalHeight);
-    const viewHeight = totalHeight * VIEW_HEIGHT_FACTOR;
-
-    const scaleX = (dimensions.width - 2 * padding) / viewWidth;
-    const scaleY = (dimensions.height - 2 * padding) / viewHeight;
-    const scale = Math.min(scaleX, scaleY) * SCALE_FACTOR;
-
-    // Center point on canvas (cart track is at vertical center-bottom area)
-    const centerX = dimensions.width / 2;
-    const groundY = dimensions.height * GROUND_Y_FACTOR;
-
-    // Transform from simulation to canvas coordinates
-    const toCanvasX = (x: number) => centerX + x * scale;
-    const toCanvasY = (y: number) => groundY - y * scale; // Flip Y axis
+    const { scale, toCanvasX, toCanvasY, groundY, centerX } = computeTransform();
 
     // Draw track
     const trackHalfWidth = (trackWidth / 2) * scale;
@@ -300,7 +236,7 @@ export function InvertedPendulumVisualization({
     // Draw track markers
     ctx.fillStyle = getCSSVariable('--text-tertiary') || '#666';
     for (let i = -5; i <= 5; i++) {
-      const markerX = centerX + (i * trackWidth / 10) * scale;
+      const markerX = centerX + ((i * trackWidth) / 10) * scale;
       ctx.beginPath();
       ctx.arc(markerX, groundY + 5, 2, 0, Math.PI * 2);
       ctx.fill();
@@ -309,11 +245,10 @@ export function InvertedPendulumVisualization({
     // Draw cart
     const cartWidth = CART_WIDTH_M * scale;
     const cartHeight = CART_HEIGHT_M * scale;
-    const cartX = toCanvasX(cart.x);
+    const cartX = toCanvasX(joints[0].x);
     const cartY = groundY;
 
-    // Cart body (highlight if touched)
-    if (highlightedElement === 'cart') {
+    if (highlighted?.type === 'cart') {
       ctx.fillStyle = '#6dd5ff';
       ctx.shadowBlur = HIGHLIGHT_GLOW_RADIUS_PX;
       ctx.shadowColor = '#6dd5ff';
@@ -335,7 +270,7 @@ export function InvertedPendulumVisualization({
 
     // Draw force arrow
     if (showForceArrow && Math.abs(controlForce) > 0.1) {
-      const maxForceDisplay = 100; // N
+      const maxForceDisplay = 200; // N
       const maxArrowLength = 80; // pixels
       const arrowLength = (controlForce / maxForceDisplay) * maxArrowLength;
 
@@ -347,13 +282,11 @@ export function InvertedPendulumVisualization({
       const arrowStartX = cartX;
       const arrowEndX = cartX + arrowLength;
 
-      // Arrow line
       ctx.beginPath();
       ctx.moveTo(arrowStartX, arrowY);
       ctx.lineTo(arrowEndX, arrowY);
       ctx.stroke();
 
-      // Arrow head
       const headSize = 8;
       const dir = controlForce > 0 ? 1 : -1;
       ctx.beginPath();
@@ -364,95 +297,81 @@ export function InvertedPendulumVisualization({
       ctx.fill();
     }
 
-    // Draw pendulum links
-    const j1x = toCanvasX(joint1.x);
-    const j1y = toCanvasY(joint1.y);
-    const j2x = toCanvasX(joint2.x);
-    const j2y = toCanvasY(joint2.y);
-    const tipX = toCanvasX(tip.x);
-    const tipY = toCanvasY(tip.y);
-
-    // Link 1
-    ctx.strokeStyle = getCSSVariable('--accent-primary') || '#6366f1';
-    ctx.lineWidth = 6;
+    // Draw the link chain.
     ctx.lineCap = 'round';
-    ctx.beginPath();
-    ctx.moveTo(j1x, j1y - cartHeight);
-    ctx.lineTo(j2x, j2y);
-    ctx.stroke();
+    const pivotX = toCanvasX(joints[0].x);
+    const pivotY = toCanvasY(joints[0].y) - cartHeight; // pivot mounted on top of cart
 
-    // Link 2
-    ctx.strokeStyle = getCSSVariable('--accent-tertiary') || '#8b5cf6';
-    ctx.beginPath();
-    ctx.moveTo(j2x, j2y);
-    ctx.lineTo(tipX, tipY);
-    ctx.stroke();
+    let prevX = pivotX;
+    let prevY = pivotY;
+    for (let i = 1; i < joints.length; i++) {
+      const jx = toCanvasX(joints[i].x);
+      const jy = toCanvasY(joints[i].y);
 
-    // Draw joints and masses
-    // Joint 1 (cart pivot)
+      ctx.strokeStyle = LINK_COLORS[(i - 1) % LINK_COLORS.length];
+      ctx.lineWidth = Math.max(3, 6 - (i - 1) * 0.4);
+      ctx.beginPath();
+      ctx.moveTo(prevX, prevY);
+      ctx.lineTo(jx, jy);
+      ctx.stroke();
+
+      prevX = jx;
+      prevY = jy;
+    }
+
+    // Pivot joint marker.
     ctx.fillStyle = getCSSVariable('--text-primary') || '#fff';
     ctx.beginPath();
-    ctx.arc(j1x, j1y - cartHeight, 6, 0, Math.PI * 2);
+    ctx.arc(pivotX, pivotY, 5, 0, Math.PI * 2);
     ctx.fill();
 
-    // Mass 1 (joint 2) - highlight if touched
-    const mass1Radius = MASS_BASE_RADIUS_PX + mass1 * MASS_RADIUS_SCALE_FACTOR;
-    if (highlightedElement === 'link1') {
-      ctx.fillStyle = '#8b87ff';
-      ctx.shadowBlur = HIGHLIGHT_GLOW_RADIUS_PX;
-      ctx.shadowColor = '#8b87ff';
-    } else {
-      ctx.fillStyle = getCSSVariable('--accent-primary') || '#6366f1';
+    // Draw masses at each link tip.
+    const massRadius = MASS_BASE_RADIUS_PX + linkMass * MASS_RADIUS_SCALE_FACTOR;
+    for (let i = 1; i < joints.length; i++) {
+      const jx = toCanvasX(joints[i].x);
+      const jy = toCanvasY(joints[i].y);
+      const color = LINK_COLORS[(i - 1) % LINK_COLORS.length];
+
+      if (highlighted?.type === 'link' && highlighted.index === i - 1) {
+        ctx.fillStyle = '#ffffff';
+        ctx.shadowBlur = HIGHLIGHT_GLOW_RADIUS_PX;
+        ctx.shadowColor = color;
+      } else {
+        ctx.fillStyle = color;
+      }
+      ctx.beginPath();
+      ctx.arc(jx, jy, massRadius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+      ctx.shadowBlur = 0;
     }
-    ctx.beginPath();
-    ctx.arc(j2x, j2y, mass1Radius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.strokeStyle = '#fff';
-    ctx.lineWidth = 2;
-    ctx.stroke();
-    ctx.shadowBlur = 0;
 
-    // Mass 2 (tip) - highlight if touched
-    const mass2Radius = MASS_BASE_RADIUS_PX + mass2 * MASS_RADIUS_SCALE_FACTOR;
-    if (highlightedElement === 'link2') {
-      ctx.fillStyle = '#b490ff';
-      ctx.shadowBlur = HIGHLIGHT_GLOW_RADIUS_PX;
-      ctx.shadowColor = '#b490ff';
-    } else {
-      ctx.fillStyle = getCSSVariable('--accent-tertiary') || '#8b5cf6';
-    }
-    ctx.beginPath();
-    ctx.arc(tipX, tipY, mass2Radius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.strokeStyle = '#fff';
-    ctx.lineWidth = 2;
-    ctx.stroke();
-    ctx.shadowBlur = 0;
-
-    // Draw telemetry overlay
+    // Telemetry overlay
     if (showTelemetry && state) {
       ctx.fillStyle = getCSSVariable('--text-primary') || '#fff';
       ctx.font = '14px monospace';
 
-      const telemetryX = 20;
-      const telemetryY = 30;
-      const lineHeight = 20;
+      const tX = 20;
+      let tY = 30;
+      const lh = 18;
 
-      ctx.fillText(`t = ${state.time.toFixed(2)} s`, telemetryX, telemetryY);
-      ctx.fillText(`x = ${state.x.toFixed(3)} m`, telemetryX, telemetryY + lineHeight);
-      ctx.fillText(`θ₁ = ${(state.theta1 * 180 / Math.PI).toFixed(1)}°`, telemetryX, telemetryY + 2 * lineHeight);
-      ctx.fillText(`θ₂ = ${(state.theta2 * 180 / Math.PI).toFixed(1)}°`, telemetryX, telemetryY + 3 * lineHeight);
-      ctx.fillText(`F = ${state.controlForce.toFixed(1)} N`, telemetryX, telemetryY + 4 * lineHeight);
+      ctx.fillText(`t = ${state.time.toFixed(2)} s`, tX, tY); tY += lh;
+      ctx.fillText(`x = ${state.x.toFixed(3)} m`, tX, tY); tY += lh;
+      const maxAng = state.angles.reduce((m, a) => Math.max(m, Math.abs(a)), 0);
+      ctx.fillText(`max|θ| = ${((maxAng * 180) / Math.PI).toFixed(1)}°`, tX, tY); tY += lh;
+      ctx.fillText(`F = ${state.controlForce.toFixed(1)} N`, tX, tY);
     }
 
-    // Draw title
+    // Title
     ctx.fillStyle = getCSSVariable('--text-secondary') || '#888';
     ctx.font = 'bold 16px sans-serif';
     ctx.textAlign = 'center';
-    ctx.fillText('Inverted Double Pendulum with LQR Control', dimensions.width / 2, 25);
+    const nLinks = joints.length - 1;
+    ctx.fillText(`Inverted ${nLinks}-Pendulum on Cart with LQR Control`, dimensions.width / 2, 25);
     ctx.textAlign = 'left';
-
-  }, [state, visualizationData, dimensions, length1, length2, mass1, mass2, showTelemetry, showForceArrow, trackWidth, highlightedElement]);
+  }, [state, visualizationData, dimensions, linkMass, numLinks, linkLength, showTelemetry, showForceArrow, trackWidth, highlighted, resolveJoints, computeTransform]);
 
   return (
     <div

--- a/web/src/components/SimulationSelector.tsx
+++ b/web/src/components/SimulationSelector.tsx
@@ -33,7 +33,7 @@ export function SimulationSelector({
     {
       type: 'pendulum' as SimulationType,
       label: 'INVPND',
-      title: 'Inverted Double Pendulum',
+      title: 'Inverted 6-Pendulum on Cart',
       description: 'LQR-controlled balancing with real-time stabilization',
       subsystem: 'CONTROL',
     },

--- a/web/src/hooks/useInvertedPendulumSimulation.ts
+++ b/web/src/hooks/useInvertedPendulumSimulation.ts
@@ -1,92 +1,13 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import type { SopotModule } from '../types/sopot';
+import type { SopotModule, InvertedPendulumSimulator } from '../types/sopot';
 import type { PendulumState, PendulumVisualizationData } from '../components/InvertedPendulumVisualization';
 import { loadSopotWasmModule } from '../utils/wasmLoader';
 
 /**
- * Interface for the InvertedPendulumSimulator from WASM
- */
-interface InvertedPendulumSimulator {
-  setupDefault(): void;
-  reset(): void;
-  step(): boolean;
-  stepWithDt(dt: number): boolean;
-  setControllerEnabled(enabled: boolean): void;
-  applyCartImpulse(impulse: number): void;
-  applyLink1Impulse(impulse: number): void;
-  applyLink2Impulse(impulse: number): void;
-  setParameters(cartMass: number, m1: number, m2: number, L1: number, L2: number, g: number): void;
-  setInitialState(x: number, theta1: number, theta2: number, xdot: number, omega1: number, omega2: number): void;
-  setTimestep(dt: number): void;
-  setMaxForce(maxForce: number): void;
-  configureLQR(qDiag: number[], r: number): void;
-
-  // State queries
-  getTime(): number;
-  getCartPosition(): number;
-  getTheta1(): number;
-  getTheta2(): number;
-  getCartVelocity(): number;
-  getOmega1(): number;
-  getOmega2(): number;
-  getControlForce(): number;
-  getFullState(): {
-    time: number;
-    x: number;
-    theta1: number;
-    theta2: number;
-    xdot: number;
-    omega1: number;
-    omega2: number;
-    controlForce: number;
-    link1Tip: { x: number; y: number };
-    link2Tip: { x: number; y: number };
-  };
-  getVisualizationData(): {
-    cart: { x: number; y: number };
-    joint1: { x: number; y: number };
-    joint2: { x: number; y: number };
-    tip: { x: number; y: number };
-    theta1: number;
-    theta2: number;
-    controlForce: number;
-  };
-
-  // Parameters
-  getCartMass(): number;
-  getMass1(): number;
-  getMass2(): number;
-  getLength1(): number;
-  getLength2(): number;
-  getGravity(): number;
-  getMaxForce(): number;
-  isInitialized(): boolean;
-  isControllerEnabled(): boolean;
-  getLQRGain(): number[];
-
-  // History
-  setRecordHistory(record: boolean): void;
-  getHistorySize(): number;
-  clearHistory(): void;
-  getHistory(): {
-    time: number[];
-    x: number[];
-    theta1: number[];
-    theta2: number[];
-    xdot: number[];
-    omega1: number[];
-    omega2: number[];
-    controlForce: number[];
-  };
-
-  delete(): void;
-}
-
-/**
- * Hook for inverted double pendulum simulation using WASM
+ * Hook for the cart-N-pendulum simulation (six inverted links) using WASM.
  *
- * All physics and control computations run in C++ via WebAssembly.
- * The frontend handles visualization and user interaction.
+ * All physics and LQR control run in C++ via WebAssembly. The frontend
+ * handles visualization and user interaction.
  */
 export function useInvertedPendulumSimulation() {
   const [isReady, setIsReady] = useState(false);
@@ -98,6 +19,7 @@ export function useInvertedPendulumSimulation() {
   const [playbackSpeed, setPlaybackSpeedState] = useState(1.0);
   const [controllerEnabled, setControllerEnabledState] = useState(true);
   const [simulationFailed, setSimulationFailed] = useState(false);
+  const [numLinks, setNumLinks] = useState(6);
 
   const moduleRef = useRef<SopotModule | null>(null);
   const simulatorRef = useRef<InvertedPendulumSimulator | null>(null);
@@ -111,15 +33,10 @@ export function useInvertedPendulumSimulation() {
     const loadModule = async () => {
       try {
         console.log('[Pendulum] Loading WASM module...');
-
-        // Load the SOPOT WebAssembly module
         const module = await loadSopotWasmModule();
-
         if (!mounted) return;
-
         moduleRef.current = module;
 
-        // Check if InvertedPendulumSimulator is available
         if (module.InvertedPendulumSimulator) {
           console.log('[Pendulum] WASM module loaded with InvertedPendulumSimulator');
           setIsReady(true);
@@ -135,10 +52,7 @@ export function useInvertedPendulumSimulation() {
     };
 
     loadModule();
-
-    return () => {
-      mounted = false;
-    };
+    return () => { mounted = false; };
   }, []);
 
   // Update state from simulator
@@ -150,12 +64,11 @@ export function useInvertedPendulumSimulation() {
     setCurrentState({
       time: fullState.time,
       x: fullState.x,
-      theta1: fullState.theta1,
-      theta2: fullState.theta2,
       xdot: fullState.xdot,
-      omega1: fullState.omega1,
-      omega2: fullState.omega2,
+      angles: fullState.angles,
+      omegas: fullState.omegas,
       controlForce: fullState.controlForce,
+      numLinks: fullState.numLinks,
     });
 
     const vizData = simulator.getVisualizationData();
@@ -164,13 +77,10 @@ export function useInvertedPendulumSimulation() {
 
   // Initialize simulation
   const initialize = useCallback((
+    initialAngleRad?: number,
     cartMass?: number,
-    m1?: number,
-    m2?: number,
-    L1?: number,
-    L2?: number,
-    initialTheta1?: number,
-    initialTheta2?: number,
+    linkMass?: number,
+    linkLength?: number,
   ) => {
     const module = moduleRef.current;
     if (!module || !module.InvertedPendulumSimulator) {
@@ -179,48 +89,40 @@ export function useInvertedPendulumSimulation() {
     }
 
     try {
-      // Clean up existing simulator
       if (simulatorRef.current) {
         simulatorRef.current.delete();
       }
 
-      // Create new simulator - we've verified InvertedPendulumSimulator exists above
-      const SimulatorClass = module.InvertedPendulumSimulator!;
+      const SimulatorClass = module.InvertedPendulumSimulator;
       simulatorRef.current = new SimulatorClass();
-      const simulator = simulatorRef.current!;
+      const simulator = simulatorRef.current;
 
-      // Set up with default or custom parameters
       simulator.setupDefault();
 
-      // Override with custom parameters if provided
-      if (cartMass !== undefined || m1 !== undefined) {
-        simulator.setParameters(
-          cartMass ?? 1.0,
-          m1 ?? 0.5,
-          m2 ?? 0.5,
-          L1 ?? 0.7,
-          L2 ?? 0.7,
-          9.81
+      if (cartMass !== undefined || linkMass !== undefined || linkLength !== undefined) {
+        simulator.setUniformParameters(
+          cartMass ?? 2.0,
+          linkMass ?? 0.1,
+          linkLength ?? 0.3,
+          9.81,
         );
+        // Re-arm controller for the new parameters.
+        simulator.setupDefault();
       }
 
-      if (initialTheta1 !== undefined || initialTheta2 !== undefined) {
-        simulator.setInitialState(
-          0,
-          initialTheta1 ?? 0.1,
-          initialTheta2 ?? 0.05,
-          0, 0, 0
-        );
+      if (initialAngleRad !== undefined) {
+        simulator.setInitialAnglesUniform(initialAngleRad);
       }
 
       simulator.reset();
+      setNumLinks(simulator.getNumLinks());
       updateState();
 
       setIsInitialized(true);
       setSimulationFailed(false);
       setError(null);
 
-      console.log('[Pendulum] Simulation initialized');
+      console.log('[Pendulum] Simulation initialized with', simulator.getNumLinks(), 'links');
       console.log('[Pendulum] LQR Gains:', simulator.getLQRGain());
     } catch (err) {
       console.error('[Pendulum] Failed to initialize:', err);
@@ -234,50 +136,41 @@ export function useInvertedPendulumSimulation() {
 
     const simulator = simulatorRef.current;
 
-    // Calculate elapsed real time
     if (lastTimeRef.current === 0) {
       lastTimeRef.current = timestamp;
     }
 
-    const realDelta = (timestamp - lastTimeRef.current) / 1000; // seconds
+    const realDelta = (timestamp - lastTimeRef.current) / 1000;
     lastTimeRef.current = timestamp;
 
-    // Calculate simulation steps based on playback speed
     const simDelta = realDelta * playbackSpeed;
-    const dt = 0.005; // 5ms fixed physics timestep
-    const steps = Math.min(Math.floor(simDelta / dt), 20); // Cap at 20 steps per frame
+    const dt = 0.002; // 2ms fixed physics timestep (stiff six-link system)
+    const steps = Math.min(Math.floor(simDelta / dt), 40);
 
-    // Run physics steps
     for (let i = 0; i < steps; i++) {
       const stillRunning = simulator.step();
       if (!stillRunning) {
-        // Pendulum has fallen
         setIsRunning(false);
         setSimulationFailed(true);
-        console.log('[Pendulum] Simulation stopped: pendulum fell');
+        console.log('[Pendulum] Simulation stopped: a pendulum fell');
         break;
       }
     }
 
-    // Update visualization state
     updateState();
 
-    // Continue animation loop
     if (isRunning && !simulationFailed) {
       animationFrameRef.current = requestAnimationFrame(animate);
     }
   }, [isRunning, playbackSpeed, simulationFailed, updateState]);
 
-  // Start/stop animation when isRunning changes
   useEffect(() => {
     if (isRunning && simulatorRef.current) {
       lastTimeRef.current = 0;
       animationFrameRef.current = requestAnimationFrame(animate);
-    } else {
-      if (animationFrameRef.current) {
-        cancelAnimationFrame(animationFrameRef.current);
-        animationFrameRef.current = null;
-      }
+    } else if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
     }
 
     return () => {
@@ -287,7 +180,6 @@ export function useInvertedPendulumSimulation() {
     };
   }, [isRunning, animate]);
 
-  // Control functions
   const start = useCallback(() => {
     if (isInitialized && !simulationFailed) {
       setIsRunning(true);
@@ -318,21 +210,13 @@ export function useInvertedPendulumSimulation() {
     }
   }, []);
 
-  const applyDisturbance = useCallback((type: 'cart' | 'link1' | 'link2', impulse: number) => {
+  const applyDisturbance = useCallback((type: 'cart' | 'link', index: number, impulse: number) => {
     if (!simulatorRef.current) return;
-
-    switch (type) {
-      case 'cart':
-        simulatorRef.current.applyCartImpulse(impulse);
-        break;
-      case 'link1':
-        simulatorRef.current.applyLink1Impulse(impulse);
-        break;
-      case 'link2':
-        simulatorRef.current.applyLink2Impulse(impulse);
-        break;
+    if (type === 'cart') {
+      simulatorRef.current.applyCartImpulse(impulse);
+    } else {
+      simulatorRef.current.applyLinkImpulse(index, impulse);
     }
-
     updateState();
   }, [updateState]);
 
@@ -348,13 +232,11 @@ export function useInvertedPendulumSimulation() {
     };
   }, []);
 
-  // Get history for plotting
   const getHistory = useCallback(() => {
     if (!simulatorRef.current) return null;
     return simulatorRef.current.getHistory();
   }, []);
 
-  // Get LQR gains
   const getLQRGains = useCallback(() => {
     if (!simulatorRef.current) return null;
     return simulatorRef.current.getLQRGain();
@@ -371,6 +253,7 @@ export function useInvertedPendulumSimulation() {
     playbackSpeed,
     controllerEnabled,
     simulationFailed,
+    numLinks,
 
     // Actions
     initialize,

--- a/web/src/types/sopot.d.ts
+++ b/web/src/types/sopot.d.ts
@@ -197,12 +197,16 @@ export interface Grid2DSimulator {
 }
 
 /**
- * Inverted Double Pendulum Simulator
+ * Cart-N-Pendulum Simulator (configured for 6 inverted pendulum links).
  */
 export interface InvertedPendulumSimulator {
   // Configuration
-  setParameters(cartMass: number, m1: number, m2: number, L1: number, L2: number, g: number): void;
-  setInitialState(x: number, theta1: number, theta2: number, xdot: number, omega1: number, omega2: number): void;
+  getNumLinks(): number;
+  setUniformParameters(cartMass: number, linkMass: number, linkLength: number, g: number): void;
+  setParameters(cartMass: number, masses: number[], lengths: number[], g: number): void;
+  setInitialAnglesUniform(angleRad: number): void;
+  setInitialState(state: number[]): void;
+  setInitialAngles(angles: number[]): void;
   setTimestep(dt: number): void;
   setMaxForce(maxForce: number): void;
   configureLQR(qDiag: number[], r: number): void;
@@ -214,38 +218,38 @@ export interface InvertedPendulumSimulator {
   stepWithDt(dt: number): boolean;
   setControllerEnabled(enabled: boolean): void;
   applyCartImpulse(impulse: number): void;
-  applyLink1Impulse(impulse: number): void;
-  applyLink2Impulse(impulse: number): void;
+  applyLinkImpulse(link: number, impulse: number): void;
 
   // State queries
   getTime(): number;
   getCartPosition(): number;
-  getTheta1(): number;
-  getTheta2(): number;
   getCartVelocity(): number;
-  getOmega1(): number;
-  getOmega2(): number;
+  getMaxAngle(): number;
   getControlForce(): number;
+  getAngles(): number[];
+  getAngularVelocities(): number[];
+  getJoints(): Array<{ x: number; y: number }>;
   getFullState(): {
     time: number;
     x: number;
+    xdot: number;
+    controlForce: number;
+    numLinks: number;
+    angles: number[];
+    omegas: number[];
+    joints: Array<{ x: number; y: number }>;
+    // Backward-compatible scalar fields (first two links)
     theta1: number;
     theta2: number;
-    xdot: number;
     omega1: number;
     omega2: number;
-    controlForce: number;
-    link1Tip: { x: number; y: number };
-    link2Tip: { x: number; y: number };
   };
   getVisualizationData(): {
     cart: { x: number; y: number };
-    joint1: { x: number; y: number };
-    joint2: { x: number; y: number };
-    tip: { x: number; y: number };
-    theta1: number;
-    theta2: number;
+    joints: Array<{ x: number; y: number }>;
+    angles: number[];
     controlForce: number;
+    numLinks: number;
   };
 
   // History
@@ -255,20 +259,14 @@ export interface InvertedPendulumSimulator {
   getHistory(): {
     time: number[];
     x: number[];
-    theta1: number[];
-    theta2: number[];
-    xdot: number[];
-    omega1: number[];
-    omega2: number[];
     controlForce: number[];
+    maxAngle: number[];
   };
 
   // Parameters
   getCartMass(): number;
-  getMass1(): number;
-  getMass2(): number;
-  getLength1(): number;
-  getLength2(): number;
+  getLinkMass(i: number): number;
+  getLinkLength(i: number): number;
   getGravity(): number;
   getMaxForce(): number;
   isInitialized(): boolean;

--- a/web/test-wasm-load.mjs
+++ b/web/test-wasm-load.mjs
@@ -62,14 +62,14 @@ async function testWasmLoading() {
         // Get initial state
         const t = pendulum.getTime();
         const x = pendulum.getCartPosition();
-        const theta1 = pendulum.getTheta1();
-        const theta2 = pendulum.getTheta2();
+        const numLinks = pendulum.getNumLinks();
+        const angles = pendulum.getAngles();
 
         console.log(`\nInitial state:`);
         console.log(`  Time: ${t.toFixed(3)}s`);
         console.log(`  Cart position: ${x.toFixed(3)}m`);
-        console.log(`  Theta1: ${theta1.toFixed(3)}rad`);
-        console.log(`  Theta2: ${theta2.toFixed(3)}rad`);
+        console.log(`  Links: ${numLinks}`);
+        console.log(`  Angles: [${angles.map((a) => a.toFixed(3)).join(', ')}] rad`);
 
         // Try a simulation step
         pendulum.step();


### PR DESCRIPTION
Replace the fixed cart-double-pendulum with a generic cart-N-pendulum and
configure the demo for six links.

Physics (C++):
- Add physics/control/cart_n_pendulum.hpp: CartNPendulum<NLinks, T>, the
  general serial inverted-pendulum-on-cart model. Mass matrix, Coriolis and
  gravity terms are derived from the Lagrangian using tail masses; the
  (N+1)x(N+1) system is solved with Gaussian elimination so it works for both
  double and autodiff Dual scalars. Reproduces the analytic double pendulum
  (N=2) to machine precision.

Control:
- lqr.hpp: add linearizeCartNPendulum<NLinks>() returning the (2N+2)-state
  A/B about the upright equilibrium (generic mass-matrix inverse + gravity
  Jacobian).
- state_feedback_controller.hpp: add CartNPendulumController<NLinks> with
  createWithLQR(), including a configurable Riccati discretization step.

Tests:
- Rewrite inverted_pendulum_test.cpp for N=6: cross-check against the analytic
  double pendulum, energy, uncontrolled fall, linearization structure, LQR
  gains, and closed-loop stabilization (all six links return to upright).

WASM + web:
- wasm_inverted_pendulum.cpp: drive CartNPendulum<6> with array-based getters
  (angles, angular velocities, joint chain) and per-link impulses.
- Update types, hook, visualization (renders an arbitrary link chain),
  control panel and App to the six-link API; keep backward-compatible
  theta1/theta2 fields in getFullState().

https://claude.ai/code/session_01T1LNF8do4RRzSbWESAkWvi