### PR TITLE
fix(web): make cart-pole Initialize button work reliably

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -316,8 +316,10 @@ function App() {
               ) : (
                 <InvertedPendulumControlPanel
                   state={pendulumSim.currentState}
+                  isReady={pendulumSim.isReady}
                   isRunning={pendulumSim.isRunning}
                   isInitialized={pendulumSim.isInitialized}
+                  error={pendulumSim.error}
                   simulationFailed={pendulumSim.simulationFailed}
                   controllerEnabled={pendulumSim.controllerEnabled}
                   playbackSpeed={pendulumSim.playbackSpeed}
@@ -481,8 +483,10 @@ function App() {
             ) : (
               <InvertedPendulumControlPanel
                 state={pendulumSim.currentState}
+                isReady={pendulumSim.isReady}
                 isRunning={pendulumSim.isRunning}
                 isInitialized={pendulumSim.isInitialized}
+                error={pendulumSim.error}
                 simulationFailed={pendulumSim.simulationFailed}
                 controllerEnabled={pendulumSim.controllerEnabled}
                 playbackSpeed={pendulumSim.playbackSpeed}

--- a/web/src/components/InvertedPendulumControlPanel.tsx
+++ b/web/src/components/InvertedPendulumControlPanel.tsx
@@ -3,8 +3,10 @@ import type { PendulumState } from './InvertedPendulumVisualization';
 
 interface InvertedPendulumControlPanelProps {
   state: PendulumState | null;
-  isRunning: boolean;
+  isReady: boolean;
   isInitialized: boolean;
+  isRunning: boolean;
+  error: string | null;
   simulationFailed: boolean;
   controllerEnabled: boolean;
   playbackSpeed: number;
@@ -21,8 +23,10 @@ interface InvertedPendulumControlPanelProps {
 
 export function InvertedPendulumControlPanel({
   state,
+  isReady,
   isRunning,
   isInitialized,
+  error,
   simulationFailed,
   controllerEnabled,
   playbackSpeed,
@@ -56,6 +60,21 @@ export function InvertedPendulumControlPanel({
         Inverted {numLinks}-Pendulum Control
       </h3>
 
+      {/* Error display */}
+      {error && (
+        <div style={{
+          padding: '12px',
+          marginBottom: '16px',
+          backgroundColor: 'rgba(248, 113, 113, 0.1)',
+          border: '1px solid var(--accent-danger)',
+          borderRadius: '6px',
+          color: 'var(--accent-danger)',
+          fontSize: '13px',
+        }}>
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
       {/* Initialization Section */}
       {!isInitialized && (
         <div style={{ marginBottom: '16px' }}>
@@ -68,6 +87,7 @@ export function InvertedPendulumControlPanel({
               type="number"
               value={initialTilt}
               step="0.1"
+              disabled={!isReady}
               onChange={(e) => setInitialTilt(parseFloat(e.target.value) || 0)}
               style={{
                 width: '100%',
@@ -82,11 +102,17 @@ export function InvertedPendulumControlPanel({
           </label>
           <button
             onClick={handleInitialize}
+            disabled={!isReady}
             className="touch-button btn-primary"
-            style={{ width: '100%' }}
+            style={{ width: '100%', opacity: isReady ? 1 : 0.5, cursor: isReady ? 'pointer' : 'not-allowed' }}
           >
             Initialize Simulation
           </button>
+          {!isReady && !error && (
+            <p style={{ margin: '8px 0 0 0', fontSize: '12px', color: 'var(--text-tertiary)' }}>
+              Loading WebAssembly module…
+            </p>
+          )}
         </div>
       )}
 

--- a/web/src/hooks/useInvertedPendulumSimulation.ts
+++ b/web/src/hooks/useInvertedPendulumSimulation.ts
@@ -99,6 +99,11 @@ export function useInvertedPendulumSimulation() {
 
       simulator.setupDefault();
 
+      // Match the fixed physics step used by the animation loop. The stiff
+      // six-link chain needs a small step (the simulator defaults to 10ms,
+      // which is too coarse and lets the chain diverge once running).
+      simulator.setTimestep(0.002);
+
       if (cartMass !== undefined || linkMass !== undefined || linkLength !== undefined) {
         simulator.setUniformParameters(
           cartMass ?? 2.0,


### PR DESCRIPTION
The inverted-pendulum (cart-pole) control panel never received the
WASM readiness or error state, unlike the rocket panel. Its Initialize
button was always enabled, so clicking it before the WASM module had
loaded (or when loading failed) hit the hook's early 'WASM module not
ready' guard and returned silently with no feedback - the button
appeared to do nothing.

- Pass isReady/error into InvertedPendulumControlPanel and gate the
  Initialize button and tilt input on readiness, mirroring the rocket
  ControlPanel. Show a loading hint and surface load errors.
- Set the simulator timestep to 2ms on initialize so the stiff
  six-link chain is integrated at the step the animation loop assumes
  (the simulator defaulted to 10ms, too coarse once running).