### PR TITLE
fix(web): improve cart-pole and mobile UX

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,6 +25,7 @@
       #root {
         width: 100vw;
         height: 100vh;
+        height: 100dvh;
       }
     </style>
   </head>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,10 +24,11 @@ function App() {
   const [showVelocities, setShowVelocities] = useState(false);
   const [showGrid, setShowGrid] = useState(true);
   const [cameraTracking, setCameraTracking] = useState(false);
-  const [mobilePanel, setMobilePanel] = useState<MobilePanel>(
-    window.innerWidth < 768 ? 'controls' : null
-  );
+  // Start with all panels closed: the visualization placeholder has its own
+  // "Start" CTA, so we don't cover the screen with a sheet on load.
+  const [mobilePanel, setMobilePanel] = useState<MobilePanel>(null);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+  const [pendingAutoStart, setPendingAutoStart] = useState(false);
 
   // Note: All hooks are instantiated to maintain React hook call order,
   // but inactive simulations are reset when switching types to free resources.
@@ -47,6 +48,14 @@ function App() {
     : simulationType === 'grid2d'
       ? gridSim
       : pendulumSim;
+
+  // Run the simulation as soon as a quick-start initialization lands
+  useEffect(() => {
+    if (pendingAutoStart && activeSim.isInitialized) {
+      activeSim.start();
+      setPendingAutoStart(false);
+    }
+  }, [pendingAutoStart, activeSim]);
 
   // Handle window resize for responsive layout
   useEffect(() => {
@@ -155,6 +164,24 @@ function App() {
     setSimulationType(type);
     setTrajectoryHistory([]);
     setTimeSeries(null);
+    setPendingAutoStart(false);
+  };
+
+  // One-tap start with sensible defaults, used by the placeholder CTA.
+  // Critical on mobile, where the control panels live behind the FAB menu.
+  const handleQuickStart = () => {
+    if (simulationType === 'rocket') {
+      Promise.resolve(
+        rocketSim.initialize({ elevation: 85, azimuth: 0, diameter: 0.16, timestep: 0.01 })
+      ).catch((err) => console.error('Quick start failed:', err));
+    } else if (simulationType === 'grid2d') {
+      Promise.resolve(gridSim.initialize()).catch((err) =>
+        console.error('Quick start failed:', err)
+      );
+    } else {
+      pendulumSim.initialize((1.7 * Math.PI) / 180);
+    }
+    setPendingAutoStart(true);
   };
 
   // Render center panel based on simulation type
@@ -187,14 +214,41 @@ function App() {
       // Pendulum simulation
       if (pendulumSim.isInitialized) {
         return (
-          <InvertedPendulumVisualization
-            state={pendulumSim.currentState}
-            visualizationData={pendulumSim.visualizationData}
-            numLinks={pendulumSim.numLinks}
-            showTelemetry={true}
-            showForceArrow={true}
-            onApplyImpulse={pendulumSim.applyDisturbance}
-          />
+          <div style={styles.visualizationWrapper}>
+            <InvertedPendulumVisualization
+              state={pendulumSim.currentState}
+              visualizationData={pendulumSim.visualizationData}
+              numLinks={pendulumSim.numLinks}
+              showTelemetry={true}
+              showForceArrow={true}
+              onApplyImpulse={pendulumSim.applyDisturbance}
+            />
+            {pendulumSim.simulationFailed ? (
+              <div style={styles.vizOverlayCenter}>
+                <div style={styles.failedCard}>
+                  <p style={styles.failedTitle}>A pendulum fell!</p>
+                  <p style={styles.failedText}>A link exceeded 45°. Reset to try again.</p>
+                  <button
+                    className="touch-button btn-danger"
+                    onClick={pendulumSim.reset}
+                    style={{ width: '100%' }}
+                  >
+                    Reset
+                  </button>
+                </div>
+              </div>
+            ) : (
+              !pendulumSim.isRunning && (
+                <button
+                  className="touch-button btn-success"
+                  style={styles.resumeChip}
+                  onClick={pendulumSim.start}
+                >
+                  ▶ {pendulumSim.currentState && pendulumSim.currentState.time > 0 ? 'Resume' : 'Run simulation'}
+                </button>
+              )
+            )}
+          </div>
         );
       }
       return renderPlaceholder('⚖️ Inverted 6-Pendulum on Cart', pendulumSim.isReady);
@@ -216,8 +270,25 @@ function App() {
         <div style={styles.placeholderContent}>
           <h1 style={styles.placeholderTitle}>{title}</h1>
           <p style={styles.placeholderText}>{description}</p>
-          <p style={styles.placeholderText}>Initialize the simulation to begin</p>
-          {!isReady && (
+          {activeSim.error && (
+            <p style={styles.placeholderError}>{activeSim.error}</p>
+          )}
+          {isReady ? (
+            <>
+              <button
+                className="touch-button btn-success"
+                style={styles.quickStartButton}
+                onClick={handleQuickStart}
+              >
+                ▶ Start Simulation
+              </button>
+              <p style={styles.placeholderHint}>
+                {isMobile
+                  ? 'Tune parameters via the menu button below'
+                  : 'Or tune parameters in the panel on the left'}
+              </p>
+            </>
+          ) : !activeSim.error && (
             <div style={styles.loadingIndicator}>
               <div style={styles.spinner} />
               <p style={styles.loadingText}>{loadingText}</p>
@@ -605,17 +676,83 @@ const styles = {
   placeholderContent: {
     textAlign: 'center' as const,
     color: '#fff',
-    padding: '40px',
+    padding: '24px',
+    maxWidth: '520px',
   },
   placeholderTitle: {
-    fontSize: '48px',
+    fontSize: 'clamp(26px, 6vw, 48px)',
     marginBottom: '20px',
     fontWeight: 'bold' as const,
   },
   placeholderText: {
-    fontSize: '20px',
+    fontSize: 'clamp(15px, 4vw, 20px)',
     marginBottom: '10px',
     opacity: 0.9,
+  },
+  placeholderError: {
+    fontSize: '14px',
+    margin: '16px 0',
+    padding: '12px',
+    borderRadius: '8px',
+    backgroundColor: 'rgba(0, 0, 0, 0.35)',
+    color: '#ffb4b4',
+    wordBreak: 'break-word' as const,
+  },
+  placeholderHint: {
+    fontSize: '13px',
+    marginTop: '12px',
+    opacity: 0.7,
+  },
+  quickStartButton: {
+    marginTop: '24px',
+    width: '100%',
+    maxWidth: '320px',
+    fontSize: '18px',
+  },
+  visualizationWrapper: {
+    position: 'relative' as const,
+    width: '100%',
+    height: '100%',
+  },
+  vizOverlayCenter: {
+    position: 'absolute' as const,
+    inset: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(10, 14, 20, 0.55)',
+    padding: '24px',
+  },
+  failedCard: {
+    backgroundColor: 'var(--bg-secondary)',
+    border: '1px solid var(--accent-red)',
+    borderRadius: '12px',
+    padding: '24px',
+    maxWidth: '320px',
+    width: '100%',
+    textAlign: 'center' as const,
+    boxShadow: '0 8px 32px rgba(0, 0, 0, 0.5)',
+  },
+  failedTitle: {
+    margin: '0 0 8px 0',
+    fontSize: '18px',
+    fontWeight: 'bold' as const,
+    color: 'var(--accent-red)',
+  },
+  failedText: {
+    margin: '0 0 16px 0',
+    fontSize: '14px',
+    color: 'var(--text-secondary)',
+  },
+  resumeChip: {
+    position: 'absolute' as const,
+    bottom: 'calc(24px + env(safe-area-inset-bottom, 0px))',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    padding: '12px 28px',
+    fontSize: '16px',
+    whiteSpace: 'nowrap' as const,
+    boxShadow: '0 4px 16px rgba(0, 0, 0, 0.5)',
   },
   loadingIndicator: {
     marginTop: '40px',

--- a/web/src/components/InvertedPendulumControlPanel.tsx
+++ b/web/src/components/InvertedPendulumControlPanel.tsx
@@ -54,7 +54,6 @@ export function InvertedPendulumControlPanel({
       padding: '16px',
       backgroundColor: 'var(--bg-secondary)',
       borderRadius: '8px',
-      maxWidth: '400px',
     }}>
       <h3 style={{ marginTop: 0, marginBottom: '16px', color: 'var(--text-primary)' }}>
         Inverted {numLinks}-Pendulum Control
@@ -85,18 +84,21 @@ export function InvertedPendulumControlPanel({
             </span>
             <input
               type="number"
+              inputMode="decimal"
               value={initialTilt}
               step="0.1"
               disabled={!isReady}
               onChange={(e) => setInitialTilt(parseFloat(e.target.value) || 0)}
               style={{
                 width: '100%',
+                minHeight: '44px',
                 padding: '8px',
                 marginTop: '4px',
                 backgroundColor: 'var(--bg-tertiary)',
                 border: '1px solid var(--border-color)',
                 borderRadius: '4px',
                 color: 'var(--text-primary)',
+                fontSize: '16px', // Prevent zoom on iOS
               }}
             />
           </label>
@@ -155,6 +157,7 @@ export function InvertedPendulumControlPanel({
               </span>
               <input
                 type="range"
+                className="touch-slider"
                 min="0.1"
                 max="5"
                 step="0.1"
@@ -192,6 +195,7 @@ export function InvertedPendulumControlPanel({
               </span>
               <input
                 type="range"
+                className="touch-slider"
                 min="1"
                 max="20"
                 step="1"
@@ -201,6 +205,12 @@ export function InvertedPendulumControlPanel({
               />
             </label>
             <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+              <button
+                onClick={() => onApplyDisturbance('cart', 0, -disturbanceStrength)}
+                style={disturbanceButtonStyle}
+              >
+                ← Push Cart
+              </button>
               <button
                 onClick={() => onApplyDisturbance('cart', 0, disturbanceStrength)}
                 style={disturbanceButtonStyle}
@@ -221,7 +231,7 @@ export function InvertedPendulumControlPanel({
               </button>
             </div>
             <p style={{ margin: '6px 0 0 0', fontSize: '11px', color: 'var(--text-tertiary)' }}>
-              Tip: click any mass in the visualization to nudge that link.
+              Tip: tap any mass to nudge that link, or tap beside the cart to push it toward that side.
             </p>
           </div>
 
@@ -303,14 +313,15 @@ export function InvertedPendulumControlPanel({
 
 const disturbanceButtonStyle: React.CSSProperties = {
   flex: 1,
-  minWidth: '90px',
-  padding: '8px',
+  minWidth: '110px',
+  minHeight: '44px', // Accessible touch target
+  padding: '8px 10px',
   backgroundColor: 'var(--bg-tertiary)',
   color: 'var(--text-primary)',
   border: '1px solid var(--border-color)',
-  borderRadius: '4px',
+  borderRadius: '6px',
   cursor: 'pointer',
-  fontSize: '12px',
+  fontSize: '13px',
 };
 
 export default InvertedPendulumControlPanel;

--- a/web/src/components/InvertedPendulumVisualization.tsx
+++ b/web/src/components/InvertedPendulumVisualization.tsx
@@ -2,8 +2,11 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 
 // Constants for touch interaction and visualization
 const CANVAS_PADDING_PX = 60; // pixels - padding around visualization area
+const CANVAS_PADDING_COMPACT_PX = 24; // pixels - padding on small screens
 const TOUCH_FEEDBACK_DURATION_MS = 200; // milliseconds - visual feedback duration
-const HIT_AREA_EXPANSION_PX = 10; // pixels - expansion of hit detection areas
+const HIT_AREA_EXPANSION_PX = 16; // pixels - expansion of hit detection areas
+const COMPACT_WIDTH_PX = 520; // below this width, use compact text and padding
+const CART_BAND_HEIGHT_FACTOR = 3; // cart-push hit band height in cart heights
 const IMPULSE_CART_NS = 5; // N·s - impulse strength for cart
 const IMPULSE_LINK_NS = 0.5; // N·s - impulse strength for links
 const MASS_BASE_RADIUS_PX = 6; // pixels - base radius for mass rendering
@@ -100,24 +103,33 @@ export function InvertedPendulumVisualization({
     return joints;
   }, [visualizationData, state, linkLength, numLinks]);
 
-  // Handle canvas resizing
+  // Handle canvas resizing (observe the container, not just the window,
+  // so orientation changes and panel toggles are picked up too).
   useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
     const updateSize = () => {
-      if (containerRef.current) {
-        const { width, height } = containerRef.current.getBoundingClientRect();
+      const { width, height } = container.getBoundingClientRect();
+      if (width > 0 && height > 0) {
         setDimensions({ width, height });
       }
     };
 
     updateSize();
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(container);
     window.addEventListener('resize', updateSize);
-    return () => window.removeEventListener('resize', updateSize);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', updateSize);
+    };
   }, []);
 
   // Compute the simulation->canvas transform (shared by render and hit testing).
   const computeTransform = useCallback(() => {
     const totalHeight = numLinks * linkLength;
-    const padding = CANVAS_PADDING_PX;
+    const padding = dimensions.width < COMPACT_WIDTH_PX ? CANVAS_PADDING_COMPACT_PX : CANVAS_PADDING_PX;
     const viewWidth = Math.max(trackWidth, 2 * totalHeight);
     const viewHeight = totalHeight * VIEW_HEIGHT_FACTOR;
 
@@ -150,7 +162,6 @@ export function InvertedPendulumVisualization({
     if (joints.length === 0) return;
 
     const { scale, toCanvasX, toCanvasY, groundY } = computeTransform();
-    const cartWidth = CART_WIDTH_M * scale;
     const cartHeight = CART_HEIGHT_M * scale;
     const massRadius = MASS_BASE_RADIUS_PX + linkMass * MASS_RADIUS_SCALE_FACTOR;
 
@@ -167,15 +178,16 @@ export function InvertedPendulumVisualization({
       }
     }
 
-    // Check cart.
+    // Check cart: any tap in the band around the track pushes the cart
+    // toward the tapped side. This gives a large, forgiving touch target
+    // and makes both push directions reachable.
     const cartX = toCanvasX(joints[0].x);
     if (
-      canvasX >= cartX - cartWidth / 2 - HIT_AREA_EXPANSION_PX &&
-      canvasX <= cartX + cartWidth / 2 + HIT_AREA_EXPANSION_PX &&
-      canvasY >= groundY - cartHeight - HIT_AREA_EXPANSION_PX &&
-      canvasY <= groundY + HIT_AREA_EXPANSION_PX
+      canvasY >= groundY - cartHeight * CART_BAND_HEIGHT_FACTOR &&
+      canvasY <= groundY + cartHeight + HIT_AREA_EXPANSION_PX
     ) {
-      onApplyImpulse('cart', 0, IMPULSE_CART_NS);
+      const direction = canvasX >= cartX ? 1 : -1;
+      onApplyImpulse('cart', 0, direction * IMPULSE_CART_NS);
       setHighlighted({ type: 'cart', index: 0 });
       setTimeout(() => setHighlighted(null), TOUCH_FEEDBACK_DURATION_MS);
     }
@@ -214,6 +226,12 @@ export function InvertedPendulumVisualization({
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
+
+    // Render at device resolution so lines stay crisp on high-DPI screens.
+    const dpr = window.devicePixelRatio || 1;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    const compact = dimensions.width < COMPACT_WIDTH_PX;
 
     // Clear canvas with background
     ctx.fillStyle = getCSSVariable('--bg-primary') || '#1a1a2e';
@@ -348,14 +366,26 @@ export function InvertedPendulumVisualization({
       ctx.shadowBlur = 0;
     }
 
+    // Title (drawn first so the telemetry overlay can start below it on
+    // narrow screens, where the two would otherwise collide)
+    ctx.fillStyle = getCSSVariable('--text-secondary') || '#888';
+    ctx.font = compact ? 'bold 13px sans-serif' : 'bold 16px sans-serif';
+    ctx.textAlign = 'center';
+    const nLinks = joints.length - 1;
+    const title = compact
+      ? `Inverted ${nLinks}-Pendulum · LQR`
+      : `Inverted ${nLinks}-Pendulum on Cart with LQR Control`;
+    ctx.fillText(title, dimensions.width / 2, compact ? 20 : 25);
+    ctx.textAlign = 'left';
+
     // Telemetry overlay
     if (showTelemetry && state) {
       ctx.fillStyle = getCSSVariable('--text-primary') || '#fff';
-      ctx.font = '14px monospace';
+      ctx.font = compact ? '12px monospace' : '14px monospace';
 
-      const tX = 20;
-      let tY = 30;
-      const lh = 18;
+      const tX = compact ? 12 : 20;
+      let tY = compact ? 44 : 30;
+      const lh = compact ? 16 : 18;
 
       ctx.fillText(`t = ${state.time.toFixed(2)} s`, tX, tY); tY += lh;
       ctx.fillText(`x = ${state.x.toFixed(3)} m`, tX, tY); tY += lh;
@@ -363,15 +393,9 @@ export function InvertedPendulumVisualization({
       ctx.fillText(`max|θ| = ${((maxAng * 180) / Math.PI).toFixed(1)}°`, tX, tY); tY += lh;
       ctx.fillText(`F = ${state.controlForce.toFixed(1)} N`, tX, tY);
     }
-
-    // Title
-    ctx.fillStyle = getCSSVariable('--text-secondary') || '#888';
-    ctx.font = 'bold 16px sans-serif';
-    ctx.textAlign = 'center';
-    const nLinks = joints.length - 1;
-    ctx.fillText(`Inverted ${nLinks}-Pendulum on Cart with LQR Control`, dimensions.width / 2, 25);
-    ctx.textAlign = 'left';
   }, [state, visualizationData, dimensions, linkMass, numLinks, linkLength, showTelemetry, showForceArrow, trackWidth, highlighted, resolveJoints, computeTransform]);
+
+  const dpr = window.devicePixelRatio || 1;
 
   return (
     <div
@@ -379,18 +403,19 @@ export function InvertedPendulumVisualization({
       style={{
         width: '100%',
         height: '100%',
-        minHeight: '400px',
+        minHeight: 0,
         position: 'relative',
       }}
     >
       <canvas
         ref={canvasRef}
-        width={dimensions.width}
-        height={dimensions.height}
+        width={Math.round(dimensions.width * dpr)}
+        height={Math.round(dimensions.height * dpr)}
         style={{
           display: 'block',
           width: '100%',
           height: '100%',
+          touchAction: 'none',
         }}
       />
     </div>

--- a/web/src/styles/responsive.css
+++ b/web/src/styles/responsive.css
@@ -92,8 +92,16 @@ body {
   flex-direction: column;
   width: 100vw;
   height: 100vh;
+  /* Dynamic viewport height: avoids content hiding behind mobile browser
+     address bars (falls back to 100vh where unsupported) */
+  height: 100dvh;
   background-color: var(--bg-primary);
   overflow: hidden;
+}
+
+.app-layout {
+  height: 100vh;
+  height: 100dvh;
 }
 
 /* ============================================
@@ -335,6 +343,7 @@ body {
     display: flex;
     flex-direction: column;
     height: 100vh;
+    height: 100dvh;
   }
 
   .top-section {
@@ -378,6 +387,7 @@ body {
     display: flex;
     flex-direction: column;
     height: 100vh;
+    height: 100dvh;
   }
 
   .top-section {
@@ -426,6 +436,7 @@ body {
     display: flex;
     flex-direction: column;
     height: 100vh;
+    height: 100dvh;
   }
 
   .top-section {
@@ -462,6 +473,7 @@ body {
     max-width: 80vw;
     border-radius: 20px 0 0 20px;
     height: 100vh !important;
+    height: 100dvh !important;
   }
 
   .bottom-sheet-backdrop {


### PR DESCRIPTION
Cart-pole visualization:
- Render the canvas at devicePixelRatio so it is crisp on high-DPI
  (mobile) screens instead of blurry
- Resize via ResizeObserver so orientation changes and panel toggles
  are picked up, and drop the 400px min-height that overflowed small
  landscape screens
- Make cart pushes directional: tapping beside the cart pushes it
  toward the tapped side, with a much larger hit band for touch
- Compact title/telemetry text on narrow screens so overlays no
  longer collide, with reduced padding to give the pendulum more room
- Show an on-canvas "pendulum fell" overlay with a Reset button and a
  Run/Resume button when paused (previously invisible on mobile)

Mobile/general UX:
- Add a one-tap "Start Simulation" CTA to the placeholder screen for
  all sims; previously mobile users had to find Initialize via
  FAB menu -> Controls, and the placeholder told them to initialize
  without offering a button
- Surface WASM load errors on the placeholder instead of only inside
  the control panel
- Stop auto-opening the controls bottom sheet over the screen on load
- Use 100dvh (with 100vh fallback) so content is not hidden behind
  mobile browser address bars
- Touch-friendly controls: 44px+ disturbance buttons, both push
  directions available, 16px font number input to prevent iOS zoom,
  touch-slider styling for range inputs

https://claude.ai/code/session_019rFLGS6w79V9ghhM3zUTng