### PR TITLE
redesign(web): promote problem selection to an always-visible tab bar

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect } from 'react';
 import * as THREE from 'three';
-import { SimulationSelector, SimulationType } from './components/SimulationSelector';
+import {
+  SimulationSelector,
+  ActiveSimulationBanner,
+  SimulationType,
+} from './components/SimulationSelector';
 import { RocketVisualization3D } from './components/RocketVisualization3D';
 import { Grid2DVisualization } from './components/Grid2DVisualization';
 import { InvertedPendulumVisualization } from './components/InvertedPendulumVisualization';
@@ -143,8 +147,11 @@ function App() {
     }
   }, [simulationType, rocketSim.isRunning, rocketSim.simulator, rocketSim.isInitialized]);
 
-  // Handle simulation type change - reset all simulations
+  // Handle simulation type change - reset all simulations.
+  // Safe to call mid-run: everything is paused before switching, so the
+  // selector stays enabled at all times.
   const handleSimulationTypeChange = (type: SimulationType) => {
+    if (type === simulationType) return;
     console.log(`[App] Switching simulation type to: ${type}`);
 
     // Pause all simulations
@@ -284,8 +291,8 @@ function App() {
               </button>
               <p style={styles.placeholderHint}>
                 {isMobile
-                  ? 'Tune parameters via the menu button below'
-                  : 'Or tune parameters in the panel on the left'}
+                  ? 'Switch problems via the tabs above · tune parameters via the menu button below'
+                  : 'Switch problems via the tabs above · tune parameters in the panel on the left'}
               </p>
             </>
           ) : !activeSim.error && (
@@ -323,15 +330,17 @@ function App() {
 
       {/* Main Layout */}
       <div className="app-layout">
+        {/* Problem selector: always-visible tab bar (all breakpoints) */}
+        <SimulationSelector
+          currentSimulation={simulationType}
+          onSimulationChange={handleSimulationTypeChange}
+        />
+
         {/* Top section: 3-column layout (desktop/tablet) */}
         <div className="top-section">
           {/* Left Panel: Controls (desktop/tablet) */}
           <div className="left-panel desktop-only">
-            <SimulationSelector
-              currentSimulation={simulationType}
-              onSimulationChange={handleSimulationTypeChange}
-              disabled={activeSim.isRunning}
-            />
+            <ActiveSimulationBanner currentSimulation={simulationType} />
 
             <div style={styles.controlPanelWrapper}>
               {simulationType === 'rocket' ? (
@@ -496,11 +505,7 @@ function App() {
             title="Controls"
             initialSnapPoint="half"
           >
-            <SimulationSelector
-              currentSimulation={simulationType}
-              onSimulationChange={handleSimulationTypeChange}
-              disabled={activeSim.isRunning}
-            />
+            <ActiveSimulationBanner currentSimulation={simulationType} />
             {simulationType === 'rocket' ? (
               <ControlPanel
                 isReady={rocketSim.isReady}

--- a/web/src/components/SimulationSelector.tsx
+++ b/web/src/components/SimulationSelector.tsx
@@ -1,172 +1,112 @@
-import { useState } from 'react';
-
 export type SimulationType = 'rocket' | 'grid2d' | 'pendulum';
+
+export interface SimulationInfo {
+  type: SimulationType;
+  label: string;
+  shortTitle: string;
+  title: string;
+  description: string;
+  subsystem: string;
+}
+
+export const SIMULATIONS: SimulationInfo[] = [
+  {
+    type: 'rocket',
+    label: 'RKTFLT',
+    shortTitle: 'Rocket Flight',
+    title: 'Rocket Flight',
+    description: '6-DOF trajectory simulation with aerodynamics',
+    subsystem: 'PROPULSION',
+  },
+  {
+    type: 'grid2d',
+    label: 'GRID2D',
+    shortTitle: 'Mass-Spring Grid',
+    title: '2D Mass-Spring Grid',
+    description: 'Deformable membrane physics simulation',
+    subsystem: 'STRUCTURAL',
+  },
+  {
+    type: 'pendulum',
+    label: 'INVPND',
+    shortTitle: 'Inverted Pendulum',
+    title: 'Inverted 6-Pendulum on Cart',
+    description: 'LQR-controlled balancing with real-time stabilization',
+    subsystem: 'CONTROL',
+  },
+];
 
 interface SimulationSelectorProps {
   currentSimulation: SimulationType;
   onSimulationChange: (type: SimulationType) => void;
-  disabled?: boolean;
 }
 
+/**
+ * Top-level problem selector, rendered as an always-visible tab bar.
+ *
+ * Selection is intentionally never disabled: switching mid-run is safe
+ * because the App-level handler pauses and resets the active simulation.
+ */
 export function SimulationSelector({
   currentSimulation,
   onSimulationChange,
-  disabled = false,
 }: SimulationSelectorProps) {
-  const [hoveredType, setHoveredType] = useState<SimulationType | null>(null);
-
-  const simulations = [
-    {
-      type: 'rocket' as SimulationType,
-      label: 'RKTFLT',
-      title: 'Rocket Flight',
-      description: '6-DOF trajectory simulation with aerodynamics',
-      subsystem: 'PROPULSION',
-    },
-    {
-      type: 'grid2d' as SimulationType,
-      label: 'GRID2D',
-      title: '2D Mass-Spring Grid',
-      description: 'Deformable membrane physics simulation',
-      subsystem: 'STRUCTURAL',
-    },
-    {
-      type: 'pendulum' as SimulationType,
-      label: 'INVPND',
-      title: 'Inverted 6-Pendulum on Cart',
-      description: 'LQR-controlled balancing with real-time stabilization',
-      subsystem: 'CONTROL',
-    },
-  ];
-
   return (
-    <div style={styles.container}>
-      <h3 style={styles.header} className="section-title">Simulation Type</h3>
-      <div style={styles.cardContainer}>
-        {simulations.map((sim) => {
+    <header className="sim-header">
+      <div className="sim-header-brand">
+        <span className="sim-header-logo">SOPOT</span>
+        <span className="sim-header-tagline">Physics Lab</span>
+      </div>
+      <nav className="sim-tabs" role="tablist" aria-label="Simulation problem">
+        {SIMULATIONS.map((sim) => {
           const isSelected = currentSimulation === sim.type;
-          const isHovered = hoveredType === sim.type;
-
           return (
             <button
               key={sim.type}
-              onClick={() => !disabled && onSimulationChange(sim.type)}
-              onMouseEnter={() => setHoveredType(sim.type)}
-              onMouseLeave={() => setHoveredType(null)}
-              disabled={disabled}
-              className="touch-button mission-panel corner-accent"
-              style={{
-                ...styles.card,
-                ...(isSelected ? styles.cardSelected : {}),
-                ...(isHovered && !disabled ? styles.cardHovered : {}),
-                ...(disabled ? styles.cardDisabled : {}),
-              }}
+              role="tab"
+              aria-selected={isSelected}
+              className={`sim-tab${isSelected ? ' sim-tab-active' : ''}`}
+              onClick={() => onSimulationChange(sim.type)}
+              title={`${sim.title} — ${sim.description}`}
             >
-              <div style={styles.labelContainer}>
-                <div className="technical-label" style={styles.label}>{sim.label}</div>
-                <div style={styles.subsystem}>{sim.subsystem}</div>
-              </div>
-              <div style={styles.cardTitle}>{sim.title}</div>
-              <div style={styles.cardDescription}>{sim.description}</div>
-              {isSelected && (
-                <div className="status-indicator active" style={styles.statusDot}></div>
-              )}
+              <span className="sim-tab-code">{sim.label}</span>
+              <span className="sim-tab-title">{sim.shortTitle}</span>
             </button>
           );
         })}
         <a
           href={`${import.meta.env.BASE_URL}winding.html`}
-          className="touch-button mission-panel corner-accent"
-          style={{ ...styles.card, textDecoration: 'none', display: 'block' }}
+          className="sim-tab sim-tab-link"
+          title="Filament Winding CAD/CAM — Oxidizer tank winding machine simulation with G-code output (opens separate tool)"
         >
-          <div style={styles.labelContainer}>
-            <div className="technical-label" style={styles.label}>FILWND</div>
-            <div style={styles.subsystem}>MANUFACTURING</div>
-          </div>
-          <div style={styles.cardTitle}>Filament Winding CAD/CAM</div>
-          <div style={styles.cardDescription}>
-            Oxidizer tank winding machine simulation with G-code output ↗
-          </div>
+          <span className="sim-tab-code">FILWND</span>
+          <span className="sim-tab-title">Filament Winding ↗</span>
         </a>
-      </div>
-    </div>
+      </nav>
+    </header>
   );
 }
 
-const styles = {
-  container: {
-    padding: '20px',
-    borderBottom: '1px solid var(--border-color)',
-    background: 'linear-gradient(180deg, var(--bg-primary) 0%, var(--bg-secondary) 100%)',
-  },
-  header: {
-    margin: '0 0 15px 0',
-    fontSize: '14px',
-    fontWeight: 600,
-    color: 'var(--text-secondary)',
-    textTransform: 'uppercase' as const,
-    letterSpacing: '2px',
-  },
-  cardContainer: {
-    display: 'flex',
-    gap: '12px',
-    flexDirection: 'column' as const,
-  },
-  card: {
-    padding: '16px',
-    cursor: 'pointer',
-    transition: 'all 0.25s ease',
-    textAlign: 'left' as const,
-    position: 'relative' as const,
-  },
-  cardSelected: {
-    borderColor: 'var(--accent-cyan)',
-    boxShadow: '0 0 16px rgba(0, 212, 255, 0.4), inset 0 1px 0 rgba(0, 212, 255, 0.2)',
-  },
-  cardHovered: {
-    transform: 'translateY(-2px)',
-    boxShadow: '0 6px 16px rgba(0, 0, 0, 0.4)',
-  },
-  cardDisabled: {
-    opacity: 0.4,
-    cursor: 'not-allowed',
-  },
-  labelContainer: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: '12px',
-  },
-  label: {
-    fontSize: '14px',
-    color: 'var(--accent-cyan)',
-    padding: '4px 8px',
-    background: 'rgba(0, 212, 255, 0.1)',
-    border: '1px solid rgba(0, 212, 255, 0.3)',
-    borderRadius: '4px',
-  },
-  subsystem: {
-    fontSize: '9px',
-    color: 'var(--text-secondary)',
-    letterSpacing: '1.5px',
-    fontWeight: 600,
-    textTransform: 'uppercase' as const,
-  },
-  cardTitle: {
-    fontSize: '16px',
-    fontWeight: 600,
-    color: 'var(--text-primary)',
-    marginBottom: '6px',
-    letterSpacing: '0.3px',
-  },
-  cardDescription: {
-    fontSize: '12px',
-    color: 'var(--text-secondary)',
-    lineHeight: '1.5',
-  },
-  statusDot: {
-    position: 'absolute' as const,
-    top: '12px',
-    right: '12px',
-  },
-};
+/**
+ * Compact summary of the currently selected problem, shown above the
+ * control panel (left panel on desktop, controls sheet on mobile).
+ */
+export function ActiveSimulationBanner({
+  currentSimulation,
+}: {
+  currentSimulation: SimulationType;
+}) {
+  const sim = SIMULATIONS.find((s) => s.type === currentSimulation);
+  if (!sim) return null;
+
+  return (
+    <div className="sim-active-banner mission-panel corner-accent">
+      <div className="sim-active-banner-row">
+        <span className="sim-active-banner-code">{sim.label}</span>
+        <span className="sim-active-banner-subsystem">{sim.subsystem}</span>
+      </div>
+      <div className="sim-active-banner-title">{sim.title}</div>
+      <div className="sim-active-banner-desc">{sim.description}</div>
+    </div>
+  );
+}

--- a/web/src/styles/responsive.css
+++ b/web/src/styles/responsive.css
@@ -100,8 +100,179 @@ body {
 }
 
 .app-layout {
+  display: flex;
+  flex-direction: column;
   height: 100vh;
   height: 100dvh;
+}
+
+/* ============================================
+   SIMULATION PROBLEM SELECTOR (top tab bar)
+   Always visible on every breakpoint so the
+   available problems are discoverable at a glance.
+   ============================================ */
+.sim-header {
+  display: flex;
+  align-items: stretch;
+  flex-shrink: 0;
+  gap: var(--spacing-md);
+  padding: 0 var(--spacing-md);
+  min-height: 60px;
+  background: linear-gradient(180deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
+  border-bottom: 2px solid var(--border-color);
+}
+
+.sim-header-brand {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex-shrink: 0;
+  padding-right: var(--spacing-md);
+  border-right: 1px solid var(--border-color);
+}
+
+.sim-header-logo {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  letter-spacing: 3px;
+  color: var(--accent-cyan);
+  text-shadow: 0 0 12px rgba(0, 212, 255, 0.4);
+}
+
+.sim-header-tagline {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.sim-tabs {
+  display: flex;
+  align-items: stretch;
+  gap: var(--spacing-xs);
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.sim-tab {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 3px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: transparent;
+  border: none;
+  border-bottom: 3px solid transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+  text-align: left;
+  text-decoration: none;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.sim-tab:hover {
+  color: var(--text-primary);
+  background: var(--grid-highlight);
+}
+
+.sim-tab-active {
+  color: var(--text-primary);
+  border-bottom-color: var(--accent-cyan);
+  background: var(--grid-highlight);
+}
+
+.sim-tab-code {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1.5px;
+}
+
+.sim-tab-active .sim-tab-code {
+  color: var(--accent-cyan);
+}
+
+.sim-tab-title {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+/* Active problem summary (above the control panel) */
+.sim-active-banner {
+  margin: var(--spacing-md);
+  padding: var(--spacing-md);
+}
+
+.sim-active-banner-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-sm);
+}
+
+.sim-active-banner-code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  color: var(--accent-cyan);
+  padding: 2px 8px;
+  background: rgba(0, 212, 255, 0.1);
+  border: 1px solid rgba(0, 212, 255, 0.3);
+  border-radius: 4px;
+}
+
+.sim-active-banner-subsystem {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.sim-active-banner-title {
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.sim-active-banner-desc {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+@media (max-width: 767px) {
+  .sim-header {
+    gap: var(--spacing-sm);
+    padding: 0 var(--spacing-sm);
+    min-height: 56px;
+  }
+
+  .sim-header-tagline {
+    display: none;
+  }
+
+  .sim-header-logo {
+    font-size: var(--font-size-md);
+  }
+
+  .sim-tab {
+    padding: var(--spacing-sm);
+  }
+
+  .sim-tab-title {
+    font-size: var(--font-size-xs);
+  }
 }
 
 /* ============================================

--- a/web/tests/simulation.spec.ts
+++ b/web/tests/simulation.spec.ts
@@ -6,38 +6,54 @@ test.describe('SOPOT Web UI', () => {
     await expect(page).toHaveTitle(/SOPOT/i);
   });
 
-  test('simulation selector is visible', async ({ page }) => {
+  test('problem selector tabs are visible', async ({ page }) => {
     await page.goto('/');
 
-    // Wait for the app to load
-    await expect(page.getByText('Simulation Type')).toBeVisible();
+    // The tab bar lists every available problem
+    const tablist = page.getByRole('tablist', { name: 'Simulation problem' });
+    await expect(tablist).toBeVisible();
 
-    // Both simulation options should be visible
-    await expect(page.getByText('Rocket Flight')).toBeVisible();
-    await expect(page.getByText('2D Mass-Spring Grid')).toBeVisible();
+    await expect(page.getByRole('tab', { name: /Rocket Flight/ })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /Mass-Spring Grid/ })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /Inverted Pendulum/ })).toBeVisible();
+  });
+
+  test('problem selector tabs are visible on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+
+    await expect(page.getByRole('tablist', { name: 'Simulation problem' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /Rocket Flight/ })).toBeVisible();
   });
 
   test('can switch to Grid2D simulation', async ({ page }) => {
     await page.goto('/');
 
-    // Click on the Grid2D simulation button
-    await page.getByText('2D Mass-Spring Grid').click();
+    // Click on the Grid2D tab
+    await page.getByRole('tab', { name: /Mass-Spring Grid/ }).click();
 
-    // Grid2D specific controls should appear
-    await expect(page.getByText('GRID2D')).toBeVisible();
+    // Tab becomes selected and Grid2D specific info appears
+    await expect(page.getByRole('tab', { name: /Mass-Spring Grid/ })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    await expect(page.getByText('GRID2D').first()).toBeVisible();
   });
 
   test('can switch back to Rocket simulation', async ({ page }) => {
     await page.goto('/');
 
     // First switch to Grid2D
-    await page.getByText('2D Mass-Spring Grid').click();
+    await page.getByRole('tab', { name: /Mass-Spring Grid/ }).click();
 
     // Then switch back to Rocket
-    await page.getByText('Rocket Flight').click();
+    await page.getByRole('tab', { name: /Rocket Flight/ }).click();
 
-    // Rocket specific elements should be visible
-    await expect(page.getByText('RKTFLT')).toBeVisible();
+    await expect(page.getByRole('tab', { name: /Rocket Flight/ })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    await expect(page.getByText('RKTFLT').first()).toBeVisible();
   });
 
   test('WASM module loads', async ({ page }) => {


### PR DESCRIPTION
The simulation/problem selector was effectively undiscoverable:
- On mobile it was buried behind FAB menu -> Controls -> bottom sheet,
  so users saw no way to pick a different problem at all.
- On desktop it was a tall stack of cards crammed above the control
  panel, and it was disabled while a simulation was running.

Redesign for clarity:
- SimulationSelector is now a top header tab bar (role=tablist) with
  SOPOT branding, rendered on every breakpoint (scrollable on mobile).
  Each tab shows the mission code + title, with the full description
  as a tooltip. The Filament Winding tool is a link tab in the same bar.
- Selection is never disabled: switching mid-run is safe because the
  App handler already pauses and resets the active simulation. Clicking
  the active tab is a no-op.
- The left panel (desktop) and Controls sheet (mobile) now show a
  compact ActiveSimulationBanner (code, subsystem, title, description)
  instead of the 4-card stack, freeing space for the actual controls.
- Placeholder hint now points users to the tabs above.
- Playwright tests updated to use role-based tab selectors, including
  a mobile-viewport visibility test.

https://claude.ai/code/session_015jEgSfGsPRvMztAf9xCrzf