### PR TITLE
Redesign problem selection UX and fix sub-problem control panels

### DIFF
--- a/web/src/components/ControlPanel.tsx
+++ b/web/src/components/ControlPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { SimulationConfig } from '../hooks/useRocketSimulation';
+import { StatusBadge } from './StatusBadge';
 
 interface ControlPanelProps {
   isReady: boolean;
@@ -54,10 +55,9 @@ export function ControlPanel({
 
   return (
     <div style={styles.container}>
-      <div style={styles.titleContainer}>
-        <div className="technical-label" style={styles.systemLabel}>SYS-SOPOT</div>
-        <h2 style={styles.title}>MISSION CONTROL</h2>
-        <div style={styles.subtitle}>6-DOF Trajectory Simulation</div>
+      <div className="ctl-panel-header">
+        <h2>Mission Control</h2>
+        <StatusBadge isReady={isReady} isInitialized={isInitialized} isRunning={isRunning} />
       </div>
 
       {/* Error display */}
@@ -288,42 +288,13 @@ export function ControlPanel({
 
 const styles = {
   container: {
-    padding: '20px',
+    padding: '0 20px 20px',
     background: 'linear-gradient(180deg, var(--bg-secondary) 0%, var(--bg-primary) 100%)',
     color: 'var(--text-primary)',
     height: '100%',
     overflowY: 'auto' as const,
     display: 'flex',
     flexDirection: 'column' as const,
-  },
-  titleContainer: {
-    marginBottom: '24px',
-    textAlign: 'center' as const,
-    borderBottom: '2px solid var(--border-color)',
-    paddingBottom: '16px',
-  },
-  systemLabel: {
-    marginBottom: '8px',
-    color: 'var(--accent-cyan)',
-    background: 'rgba(0, 212, 255, 0.1)',
-    border: '1px solid rgba(0, 212, 255, 0.3)',
-    padding: '4px 12px',
-    borderRadius: '4px',
-    display: 'inline-block',
-  },
-  title: {
-    margin: '8px 0',
-    fontSize: '22px',
-    fontWeight: 700,
-    color: 'var(--text-primary)',
-    letterSpacing: '2px',
-  },
-  subtitle: {
-    fontSize: '11px',
-    color: 'var(--text-secondary)',
-    textTransform: 'uppercase' as const,
-    letterSpacing: '1.5px',
-    marginTop: '4px',
   },
   section: {
     marginBottom: '16px',

--- a/web/src/components/Grid2DControlPanel.tsx
+++ b/web/src/components/Grid2DControlPanel.tsx
@@ -1,6 +1,7 @@
 import type { GridTopology, IntegratorType } from '../types/sopot';
 import type { GridSize } from '../hooks/useGrid2DSimulation';
 import { SUPPORTED_GRID_SIZES, SUPPORTED_INTEGRATORS, INTEGRATOR_LABELS } from '../hooks/useGrid2DSimulation';
+import { StatusBadge } from './StatusBadge';
 
 interface Grid2DControlPanelProps {
   isReady: boolean;
@@ -77,23 +78,9 @@ export function Grid2DControlPanel({
   return (
     <div style={styles.container}>
       {/* Header */}
-      <div style={styles.header}>
-        <h2 style={styles.title}>2D Grid Controls</h2>
-        <div style={styles.statusBadge}>
-          <div
-            style={{
-              ...styles.statusDot,
-              backgroundColor: isRunning
-                ? 'var(--accent-green)'
-                : isInitialized
-                ? 'var(--accent-amber)'
-                : 'var(--text-secondary)',
-            }}
-          />
-          <span style={styles.statusText}>
-            {isRunning ? 'Running' : isInitialized ? 'Ready' : 'Stopped'}
-          </span>
-        </div>
+      <div className="ctl-panel-header">
+        <h2>Grid Controls</h2>
+        <StatusBadge isReady={isReady} isInitialized={isInitialized} isRunning={isRunning} />
       </div>
 
       {/* Error Display */}
@@ -422,29 +409,6 @@ const styles = {
     overflowY: 'auto' as const,
     display: 'flex',
     flexDirection: 'column' as const,
-  },
-  header: {
-    padding: '20px',
-    borderBottom: '2px solid var(--bg-tertiary)',
-  },
-  title: {
-    margin: '0 0 10px 0',
-    fontSize: '20px',
-    fontWeight: 'bold' as const,
-  },
-  statusBadge: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-  },
-  statusDot: {
-    width: '10px',
-    height: '10px',
-    borderRadius: '50%',
-  },
-  statusText: {
-    fontSize: '14px',
-    color: 'var(--text-secondary)',
   },
   errorBox: {
     margin: '10px 20px',

--- a/web/src/components/InvertedPendulumControlPanel.tsx
+++ b/web/src/components/InvertedPendulumControlPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { PendulumState } from './InvertedPendulumVisualization';
+import { StatusBadge } from './StatusBadge';
 
 interface InvertedPendulumControlPanelProps {
   state: PendulumState | null;
@@ -51,14 +52,19 @@ export function InvertedPendulumControlPanel({
 
   return (
     <div className="control-panel" style={{
-      padding: '16px',
       backgroundColor: 'var(--bg-secondary)',
-      borderRadius: '8px',
     }}>
-      <h3 style={{ marginTop: 0, marginBottom: '16px', color: 'var(--text-primary)' }}>
-        Inverted {numLinks}-Pendulum Control
-      </h3>
+      <div className="ctl-panel-header">
+        <h2>{numLinks}-Pendulum Control</h2>
+        <StatusBadge
+          isReady={isReady}
+          isInitialized={isInitialized}
+          isRunning={isRunning}
+          failed={simulationFailed}
+        />
+      </div>
 
+      <div style={{ padding: '16px' }}>
       {/* Error display */}
       {error && (
         <div style={{
@@ -307,6 +313,7 @@ export function InvertedPendulumControlPanel({
           )}
         </>
       )}
+      </div>
     </div>
   );
 }

--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -1,0 +1,30 @@
+interface StatusBadgeProps {
+  isReady: boolean;
+  isInitialized: boolean;
+  isRunning: boolean;
+  /** Optional override label/state (e.g. "Failed" for the pendulum). */
+  failed?: boolean;
+}
+
+/**
+ * Shared run-state indicator used at the top of every sub-problem control
+ * panel so the three simulations read consistently.
+ */
+export function StatusBadge({ isReady, isInitialized, isRunning, failed }: StatusBadgeProps) {
+  const { label, className } = failed
+    ? { label: 'Failed', className: 'inactive' }
+    : isRunning
+      ? { label: 'Running', className: 'active' }
+      : isInitialized
+        ? { label: 'Ready', className: 'standby' }
+        : isReady
+          ? { label: 'Standby', className: 'standby' }
+          : { label: 'Loading…', className: 'inactive' };
+
+  return (
+    <div className="ctl-status">
+      <span className={`status-indicator ${className}`} />
+      <span className="ctl-status-text">{label}</span>
+    </div>
+  );
+}

--- a/web/src/styles/responsive.css
+++ b/web/src/styles/responsive.css
@@ -14,11 +14,13 @@
   --bg-tertiary: #1a2332;       /* Card backgrounds */
   --text-primary: #c5d4e8;      /* Light technical blue-gray */
   --text-secondary: #7a8a9e;    /* Medium technical gray */
+  --text-tertiary: #5a6a7e;     /* Dim technical gray (hints, captions) */
   --border-color: #2a3f5f;      /* Steel blue borders */
   --accent-cyan: #00d4ff;       /* Telemetry data (primary accent) */
   --accent-green: #00ff88;      /* Go/Success status */
   --accent-amber: #ffaa00;      /* Warning/Caution */
   --accent-red: #ff3b3b;        /* Critical/Danger */
+  --accent-danger: #ff3b3b;     /* Alias of --accent-red for control panels */
 
   /* Technical grid overlay */
   --grid-color: rgba(42, 63, 95, 0.3);
@@ -206,6 +208,43 @@ body {
   letter-spacing: 0.3px;
 }
 
+/* ============================================
+   SHARED CONTROL-PANEL PRIMITIVES
+   Used by every sub-problem control panel so the
+   three simulations read as one coherent UI.
+   ============================================ */
+.ctl-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.ctl-panel-header h2 {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  color: var(--text-primary);
+}
+
+.ctl-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.ctl-status-text {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
 /* Active problem summary (above the control panel) */
 .sim-active-banner {
   margin: var(--spacing-md);
@@ -349,6 +388,11 @@ body {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    /* Sit above the full-screen backdrop (z-index 999); without an explicit
+       stacking position the backdrop paints over the menu and swallows taps,
+       making the menu items (e.g. "Controls") appear dead. */
+    position: relative;
+    z-index: 1000;
     animation: slideUpFab 0.2s ease-out;
   }
 

--- a/web/tests/simulation.spec.ts
+++ b/web/tests/simulation.spec.ts
@@ -56,6 +56,20 @@ test.describe('SOPOT Web UI', () => {
     await expect(page.getByText('RKTFLT').first()).toBeVisible();
   });
 
+  test('mobile FAB Controls button opens the controls sheet', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+
+    // Open the floating action menu, then tap the "Controls" (settings) item.
+    // Regression: the full-screen backdrop used to paint over the menu items
+    // and swallow the tap, so the sheet never opened.
+    await page.getByRole('button', { name: 'Open menu' }).click();
+    await page.getByRole('button', { name: 'Controls' }).click();
+
+    // The controls sheet should now be visible with the rocket panel inside.
+    await expect(page.getByText('Mission Control')).toBeVisible();
+  });
+
   test('WASM module loads', async ({ page }) => {
     await page.goto('/');
 


### PR DESCRIPTION
## Summary

The simulation/problem selector was effectively undiscoverable, and the per-problem control UIs had a dead button plus inconsistent styling. This redesigns selection into a clear, always-visible tab bar and repairs the individual sub-problem panels.

### Problem selection
- **Always-visible top tab bar** (`role=tablist`) with SOPOT branding, rendered on every breakpoint (scrollable on mobile). Previously the selector was buried behind the mobile FAB → Controls → bottom sheet (invisible), and on desktop it was a tall card stack that got *disabled while running*.
- Each tab shows the mission code + title, full description as a tooltip. The Filament Winding tool is a link tab in the same bar.
- Selection is never disabled — switching mid-run is safe because the handler already pauses and resets the active simulation. Clicking the active tab is a no-op.
- The desktop left panel and mobile Controls sheet now show a compact **ActiveSimulationBanner** instead of the 4-card stack, freeing space for actual controls.

### Sub-problem control panel fixes
- **Mobile FAB "Controls" (settings) button was dead.** The full-screen `.fab-backdrop` (positioned, `z-index: 999`) painted above the statically-positioned `.fab-menu`, so within the FAB stacking context the backdrop swallowed every tap — opening the menu and tapping any item just dismissed it. Gave `.fab-menu` an explicit `position`/`z-index` above the backdrop.
- **Missing CSS variables.** The inverted-pendulum panel referenced `--text-tertiary` and `--accent-danger`, neither of which existed; its hint text inherited the wrong color and its error/warning borders silently disappeared. Both are now defined.
- **Inconsistent headers.** Added a shared `StatusBadge` + `.ctl-panel-header` so all three panels (rocket, grid, pendulum) present a consistent compact header with a live Running/Ready/Standby/Loading indicator — replacing the rocket panel's oversized `MISSION CONTROL` banner (now redundant) and the grid panel's bespoke badge.

### Tests
- Updated Playwright tests to role-based tab selectors, incl. a mobile-viewport visibility test.
- Added a regression test that opens the FAB menu and confirms the Controls sheet appears.

## Verification
- `tsc --noEmit` clean; `vite build` clean.
- Dev server serves 200 and all changed modules transform without error.
- ⚠️ The Playwright suite could **not** be run in the dev environment — the network policy blocks the browser CDN (`403 Host not in allowlist`), so Chromium can't be installed here. The tests are valid and should run in CI / locally via `npm test`.

https://claude.ai/code/session_015jEgSfGsPRvMztAf9xCrzf

---
_Generated by [Claude Code](https://claude.ai/code/session_015jEgSfGsPRvMztAf9xCrzf)_